### PR TITLE
fix: publish of argilla-server Python package to PyPI using wrong Python version

### DIFF
--- a/.github/workflows/build-python-package.yml
+++ b/.github/workflows/build-python-package.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: "18"
       - name: Setup PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
           cache: true
       - name: Install dependencies

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,8 +24,6 @@ on:
       - "feature/**"
       - "feat/**"
       - "fix/**"
-      # TODO: Delete this after we check that everything is working as expected.
-      - "project-creation-with-pdm"
     types:
       - opened
       - reopened
@@ -191,7 +189,7 @@ jobs:
           name: python-package
           path: dist
       - name: Setup PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
           cache: true
       - name: Publish Package to PyPI test environment 🥪

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -66,9 +66,8 @@ jobs:
           echo "ARGILLA_SEARCH_ENGINE=opensearch" >> "$GITHUB_ENV"
           echo "Configure opensearch engine"
       - name: Setup PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
-          python-version: 3.10.13
           cache: true
       - name: Install dependencies
         run: pdm install

--- a/src/argilla_server/_version.py
+++ b/src/argilla_server/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-__version__ = "1.23.0-dev4"
+__version__ = "1.23.0-dev3"

--- a/src/argilla_server/_version.py
+++ b/src/argilla_server/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-__version__ = "1.23.0-dev2"
+__version__ = "1.23.0-dev4"


### PR DESCRIPTION
# Description

Looks like a bug on [setup-pdm](https://github.com/pdm-project/setup-pdm) action was not correctly reading the Python version from `pyproject.toml` and causing to use the default version from `ubuntu-latest` container (v3.12 for this case).

Upgrading from `pdm-project/setup-pdm@v3` to `pdm-project/setup-pdm@v4` looks like fixing the issue.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [ ] Python package should be correctly build and pushed to PyPI

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)