### PR TITLE
fix: Clean providers list when oauth config is disabled

### DIFF
--- a/src/argilla_server/apis/v1/handlers/oauth2.py
+++ b/src/argilla_server/apis/v1/handlers/oauth2.py
@@ -36,9 +36,10 @@ _USER_ROLE_ON_CREATION = UserRole.annotator
 
 @router.get("/providers", response_model=Providers)
 def list_providers(_request: Request) -> Providers:
-    items = [Provider(name=provider_name) for provider_name in settings.oauth.providers]
+    if not settings.oauth.enabled:
+        return Providers(items=[])
 
-    return Providers(items=items)
+    return Providers(items=[Provider(name=provider_name) for provider_name in settings.oauth.providers])
 
 
 @router.get("/providers/{provider}/authentication")

--- a/src/argilla_server/security/authentication/oauth2/settings.py
+++ b/src/argilla_server/security/authentication/oauth2/settings.py
@@ -55,9 +55,6 @@ class OAuth2Settings:
         self.enabled = enabled
         self.allow_http_redirect = allow_http_redirect
         self.allowed_workspaces = allowed_workspaces or []
-
-        if not enabled:
-            providers = []
         self._providers = providers or []
 
         if self.allow_http_redirect:

--- a/src/argilla_server/security/authentication/oauth2/settings.py
+++ b/src/argilla_server/security/authentication/oauth2/settings.py
@@ -56,6 +56,8 @@ class OAuth2Settings:
         self.allow_http_redirect = allow_http_redirect
         self.allowed_workspaces = allowed_workspaces or []
 
+        if not enabled:
+            providers = []
         self._providers = providers or []
 
         if self.allow_http_redirect:

--- a/tests/unit/api/v1/test_oauth2.py
+++ b/tests/unit/api/v1/test_oauth2.py
@@ -119,9 +119,7 @@ class TestOauth2:
         default_oauth_settings: OAuth2Settings,
     ):
         default_oauth_settings.enabled = False
-        with mock.patch(
-            "argilla_server.security.settings.Settings.oauth", new_callable=lambda: default_oauth_settings
-        ):
+        with mock.patch("argilla_server.security.settings.Settings.oauth", new_callable=lambda: default_oauth_settings):
             response = await async_client.get(
                 "/api/v1/oauth2/providers/huggingface/authentication", headers=owner_auth_header
             )

--- a/tests/unit/api/v1/test_oauth2.py
+++ b/tests/unit/api/v1/test_oauth2.py
@@ -67,6 +67,15 @@ class TestOauth2:
             assert response.status_code == 200
             assert response.json() == {"items": []}
 
+    async def test_list_provider_with_oauth_disabled_from_settings(
+        self, async_client: AsyncClient, owner_auth_header: dict, default_oauth_settings: OAuth2Settings
+    ):
+        default_oauth_settings.enabled = False
+        with mock.patch("argilla.server.security.settings.Settings.oauth", new_callable=lambda: default_oauth_settings):
+            response = await async_client.get("/api/v1/oauth2/providers", headers=owner_auth_header)
+            assert response.status_code == 200
+            assert response.json() == {"items": []}
+
     async def test_list_providers(
         self, async_client: AsyncClient, owner_auth_header: dict, default_oauth_settings: OAuth2Settings
     ):

--- a/tests/unit/api/v1/test_oauth2.py
+++ b/tests/unit/api/v1/test_oauth2.py
@@ -112,6 +112,21 @@ class TestOauth2:
             )
             assert response.status_code == 404
 
+    async def test_provider_authentication_with_oauth_disabled_and_provider_defined(
+        self,
+        async_client: AsyncClient,
+        owner_auth_header: dict,
+        default_oauth_settings: OAuth2Settings,
+    ):
+        default_oauth_settings.enabled = False
+        with mock.patch(
+            "argilla_server.security.settings.Settings.oauth", new_callable=lambda: default_oauth_settings
+        ):
+            response = await async_client.get(
+                "/api/v1/oauth2/providers/huggingface/authentication", headers=owner_auth_header
+            )
+            assert response.status_code == 404
+
     async def test_provider_authentication_with_invalid_provider(
         self, async_client: AsyncClient, owner_auth_header: dict, default_oauth_settings: OAuth2Settings
     ):

--- a/tests/unit/api/v1/test_oauth2.py
+++ b/tests/unit/api/v1/test_oauth2.py
@@ -71,7 +71,7 @@ class TestOauth2:
         self, async_client: AsyncClient, owner_auth_header: dict, default_oauth_settings: OAuth2Settings
     ):
         default_oauth_settings.enabled = False
-        with mock.patch("argilla.server.security.settings.Settings.oauth", new_callable=lambda: default_oauth_settings):
+        with mock.patch("argilla_server.security.settings.Settings.oauth", new_callable=lambda: default_oauth_settings):
             response = await async_client.get("/api/v1/oauth2/providers", headers=owner_auth_header)
             assert response.status_code == 200
             assert response.json() == {"items": []}


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

When `.oauth.yaml` file contains `enabled: false`, the oauth endpoints return the configured provider info. This PR fixes it and set an empty list when `enabled=False`

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Running locally and HF spaces

- [ ] Test A
- [ ] Test B

**Checklist**

- [X] I followed the style guidelines of this project
- [X] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
