### PR TITLE
fix: Using `settings.base_url` to setup base url path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed problems using `ARGILLA_BASE_URL` environment variable. ([#14](https://github.com/argilla-io/argilla-server/pull/14))
+
 ## [1.23.0](https://github.com/argilla-io/argilla/compare/v1.22.0...v1.23.0)
 
 ### Added

--- a/src/argilla_server/_app.py
+++ b/src/argilla_server/_app.py
@@ -95,7 +95,12 @@ def create_server_app() -> FastAPI:
     ]:
         app_configure(app)
 
-    return app
+    if settings.base_url and settings.base_url != "/":
+        _app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+        _app.mount(settings.base_url, app)
+        return _app
+    else:
+        return app
 
 
 def configure_middleware(app: FastAPI):

--- a/src/argilla_server/_app.py
+++ b/src/argilla_server/_app.py
@@ -95,12 +95,10 @@ def create_server_app() -> FastAPI:
     ]:
         app_configure(app)
 
-    if settings.base_url and settings.base_url != "/":
-        _app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
-        _app.mount(settings.base_url, app)
-        return _app
-    else:
-        return app
+    _app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+    _app.mount(settings.base_url, app)
+
+    return _app
 
 
 def configure_middleware(app: FastAPI):

--- a/src/argilla_server/_app.py
+++ b/src/argilla_server/_app.py
@@ -95,10 +95,14 @@ def create_server_app() -> FastAPI:
     ]:
         app_configure(app)
 
-    _app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
-    _app.mount(settings.base_url, app)
-
-    return _app
+    # This if-else clause is needed to simplify the test dependencies setup. Otherwise we cannot override dependencies
+    # easily. We can review this once we have separate fastapi application for the api and the webapp.
+    if settings.base_url and settings.base_url != "/":
+        _app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+        _app.mount(settings.base_url, app)
+        return _app
+    else:
+        return app
 
 
 def configure_middleware(app: FastAPI):

--- a/src/argilla_server/static_rewrite.py
+++ b/src/argilla_server/static_rewrite.py
@@ -25,9 +25,6 @@ class RewriteStaticFiles(StaticFiles):
 
     async def get_response(self, path: str, scope: Scope) -> Response:
         try:
-            # Normalize path to avoid redirections
-            if not scope["path"].endswith("/"):
-                scope["path"] += "/"
             response = await super().get_response(path, scope)
             return await self._handle_response(response, scope)
         except HTTPException as ex:
@@ -39,7 +36,7 @@ class RewriteStaticFiles(StaticFiles):
         scope,
     ):
         if self.html and (response_or_error.status_code == 404):
-            return await super().get_response(path="", scope=scope)
+            return await super().get_response(path="/", scope=scope)
         if isinstance(response_or_error, HTTPException):
             raise response_or_error
         return response_or_error

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,0 +1,30 @@
+from typing import cast
+
+from starlette.routing import Mount
+from starlette.testclient import TestClient
+
+from argilla_server.settings import settings
+from argilla_server._app import create_server_app
+
+
+class TestApp:
+    def test_create_app_with_base_url(self, owner_auth_header: dict):
+        settings.base_url = "/new/base/url"
+        app = create_server_app()
+
+        client = TestClient(app)
+
+        response = client.get("/")
+        assert response.status_code == 404
+
+        response = client.get("/new/base/url")
+        assert response.status_code == 200
+
+        response = client.get("/api/_info")
+        assert response.status_code == 404
+
+        response = client.get("/new/base/url/api/_info")
+        assert response.status_code == 200
+
+        assert len(app.routes) == 1
+        assert cast(Mount, app.routes[0]).path == "/new/base/url"

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -14,11 +14,11 @@
 from typing import cast
 
 import pytest
+from argilla_server._app import create_server_app
+from argilla_server.settings import Settings, settings
 from starlette.routing import Mount
 from starlette.testclient import TestClient
 
-from argilla_server._app import create_server_app
-from argilla_server.settings import Settings, settings
 
 @pytest.fixture
 def test_settings():

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,10 +1,23 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from typing import cast
 
+from argilla_server._app import create_server_app
+from argilla_server.settings import settings
 from starlette.routing import Mount
 from starlette.testclient import TestClient
-
-from argilla_server.settings import settings
-from argilla_server._app import create_server_app
 
 
 class TestApp:


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR introduces changes to allow configuring a base path using `ARGILLA_BASE_URL` without requiring an external proxy. 

If you want to run argilla behind a proxy without changing base URL (which means defining a pathRewrite rule in your proxy), you should use the `UVICORN_ROOT_PATH` env variable. For more info visit https://fastapi.tiangolo.com/advanced/behind-a-proxy/#behind-a-proxy and https://www.uvicorn.org/settings/

Related PR: https://github.com/argilla-io/argilla/pull/3543
Closes https://github.com/argilla-io/argilla/issues/4568

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
