### PR TITLE
fix: remove `--root-path` param when running the docker image with the `ARGILLA_BASE_URL` enabled

### DIFF
--- a/docker/quickstart/scripts/start_quickstart_argilla.sh
+++ b/docker/quickstart/scripts/start_quickstart_argilla.sh
@@ -42,8 +42,4 @@ python load_data.py "$OWNER_API_KEY" "$LOAD_DATASETS" &
 
 # Start Argilla
 echo "Starting Argilla"
-if [ -n "$ARGILLA_BASE_URL" ]; then
-	uvicorn argilla_server:app --host "0.0.0.0" --root-path "$ARGILLA_BASE_URL"
-else
-	uvicorn argilla_server:app --host "0.0.0.0"
-fi
+python -m uvicorn argilla_server:app --host "0.0.0.0"

--- a/docker/server/scripts/start_argilla_server.sh
+++ b/docker/server/scripts/start_argilla_server.sh
@@ -16,10 +16,4 @@ fi
 #   with the prefix UVICORN_. For example, in case you want to
 #   run the app on port 5000, just set the environment variable
 #   UVICORN_PORT to 5000.
-
-# Check for ARGILLA_BASE_URL and add --root-path if present
-if [ -n "$ARGILLA_BASE_URL" ]; then
-	python -m uvicorn argilla_server:app --host "0.0.0.0" --root-path "$ARGILLA_BASE_URL"
-else
-	python -m uvicorn argilla_server:app --host "0.0.0.0"
-fi
+python -m uvicorn argilla_server:app --host "0.0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "python-jose[cryptography] >= 3.2,< 3.4",
     "passlib[bcrypt] ~= 1.7.4",
     # OAuth2 integration
+    "httpx>=0.26.0",
     "oauthlib ~= 3.2.0",
     "social-auth-core ~= 4.5.0",
     # Info status
@@ -164,5 +165,5 @@ line-length = 120
 line-length = 120
 
 [tool.pdm.scripts]
-build-server-image = { shell = "cp -R dist docker/server && docker build -t argilla/argilla-server docker/server" }
-build-quickstart-image = { shell ="cp -R dist docker/quickstart && docker build -t argilla/argilla-quickstart docker/quickstart" }
+build-server-image = { shell = "cp -R dist docker/server && docker build -t argilla/argilla-server:local docker/server" }
+build-quickstart-image = { shell ="docker build --build-arg ARGILLA_VERSION=local -t argilla/argilla-quickstart:local docker/quickstart" }


### PR DESCRIPTION
This fix is related to work developed in #14

This change is still compatible with a proxied configuration. To make it work using an nginx proxy configuration as defined [here](https://github.com/argilla-io/argilla/blob/develop/docker/nginx/nginx.conf), you should adapt the target server to adding the configured base URL:
```conf
events {}

http {
  server {
      listen 80;

      location /argilla/ {
          proxy_pass http://argilla:6900/argilla; # <- this line adds the `/argilla` path
          proxy_set_header Host $host;
          proxy_set_header X-Real-IP $remote_addr;
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header X-Forwarded-Proto $scheme;
      }
  }
}
```

