### PR TITLE
feat: add different deterministic sorting of records per user

### DIFF
--- a/src/argilla_server/apis/v1/handlers/datasets/records.py
+++ b/src/argilla_server/apis/v1/handlers/datasets/records.py
@@ -261,6 +261,9 @@ async def _get_search_responses(
             "sort_by": sort_by,
         }
 
+        if user is not None:
+            search_params["user_id"] = user.id
+
         if filters:
             search_params["filter"] = _to_search_engine_filter(filters, user=user)
         if sort:
@@ -420,7 +423,7 @@ async def list_current_user_dataset_records(
         user=current_user,
         response_statuses=response_statuses,
         include=include,
-        sort_by_query_param=sort_by_query_param or LIST_DATASET_RECORDS_DEFAULT_SORT_BY,
+        sort_by_query_param=sort_by_query_param,
     )
 
     return Records(items=records, total=total)

--- a/src/argilla_server/search_engine/commons.py
+++ b/src/argilla_server/search_engine/commons.py
@@ -209,7 +209,7 @@ def _unify_metadata_filters_with_filter(metadata_filters: List[MetadataFilter], 
 
 # This function will be moved once the response status filter is removed from search and similarity_search methods
 def _unify_user_response_status_filter_with_filter(
-    user_response_status_filter: UserResponseStatusFilter, filter: Optional[Filter]
+    user_response_status_filter: UserResponseStatusFilter, filter: Optional[Filter] = None
 ) -> Filter:
     scope = ResponseFilterScope(user=user_response_status_filter.user, property="status")
     response_filter = TermsFilter(scope=scope, values=[status.value for status in user_response_status_filter.statuses])
@@ -235,6 +235,28 @@ def _unify_sort_by_with_order(sort_by: List[SortBy], order: List[Order]) -> List
         new_order.append(Order(scope=scope, order=sort.order))
 
     return new_order
+
+
+def is_response_status_scope(scope: FilterScope) -> bool:
+    if not isinstance(scope, ResponseFilterScope):
+        return False
+
+    if not scope.property == "status":
+        return False
+
+    if scope.question is not None:
+        return False
+
+    return True
+
+
+def is_only_pending_response_status_filter(filter: Optional[Filter] = None) -> bool:
+    return (
+        bool(filter)
+        and not isinstance(filter, AndFilter)
+        and is_response_status_scope(filter.scope)
+        and filter.values == ["pending"]
+    )
 
 
 @dataclasses.dataclass
@@ -410,18 +432,6 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         return await self._process_search_response(response, threshold)
 
     def build_elasticsearch_filter(self, filter: Filter) -> Dict[str, Any]:
-        def is_response_status_scope(scope: FilterScope) -> bool:
-            if not isinstance(scope, ResponseFilterScope):
-                return False
-
-            if not scope.property == "status":
-                return False
-
-            if scope.question is not None:
-                return False
-
-            return True
-
         if isinstance(filter, AndFilter):
             filters = [self.build_elasticsearch_filter(f) for f in filter.filters]
             return es_bool_query(should=filters, minimum_should_match=len(filters))
@@ -561,6 +571,7 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         # END TODO
         offset: int = 0,
         limit: int = 100,
+        user_id: Optional[str] = None,
     ) -> SearchResponses:
         # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
 
@@ -581,6 +592,16 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
             bool_query["filter"] = self.build_elasticsearch_filter(filter)
 
         es_query = {"bool": bool_query}
+
+        # special kellogs case to display the records with pending status
+        if is_only_pending_response_status_filter(filter):
+            es_query = {
+                "function_score": {
+                    "query": es_query,
+                    "functions": [{"random_score": {"seed": str(user_id), "field": "_seq_no"}}],
+                }
+            }
+
         index = await self._get_dataset_index(dataset)
 
         es_sort = self.build_elasticsearch_sort(sort) if sort else None

--- a/src/argilla_server/search_engine/commons.py
+++ b/src/argilla_server/search_engine/commons.py
@@ -238,16 +238,11 @@ def _unify_sort_by_with_order(sort_by: List[SortBy], order: List[Order]) -> List
 
 
 def is_response_status_scope(scope: FilterScope) -> bool:
-    if not isinstance(scope, ResponseFilterScope):
-        return False
-
-    if not scope.property == "status":
-        return False
-
-    if scope.question is not None:
-        return False
-
-    return True
+    return (
+        isinstance(scope, ResponseFilterScope) and
+        scope.property == "status" and 
+        scope.question is None
+    )
 
 
 @dataclasses.dataclass

--- a/src/argilla_server/search_engine/commons.py
+++ b/src/argilla_server/search_engine/commons.py
@@ -238,11 +238,7 @@ def _unify_sort_by_with_order(sort_by: List[SortBy], order: List[Order]) -> List
 
 
 def is_response_status_scope(scope: FilterScope) -> bool:
-    return (
-        isinstance(scope, ResponseFilterScope) and
-        scope.property == "status" and 
-        scope.question is None
-    )
+    return isinstance(scope, ResponseFilterScope) and scope.property == "status" and scope.question is None
 
 
 @dataclasses.dataclass

--- a/src/argilla_server/search_engine/elasticsearch.py
+++ b/src/argilla_server/search_engine/elasticsearch.py
@@ -134,7 +134,7 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
         query: dict,
         size: Optional[int] = None,
         from_: Optional[int] = None,
-        sort: str = None,
+        sort: Optional[str] = None,
         aggregations: Optional[dict] = None,
     ) -> dict:
         return await self.client.search(
@@ -144,7 +144,7 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
             size=size,
             source=False,
             aggregations=aggregations,
-            sort=sort or "_score:desc,id:asc",
+            sort=sort,
             track_total_hits=True,
         )
 

--- a/tests/unit/api/v1/test_datasets.py
+++ b/tests/unit/api/v1/test_datasets.py
@@ -4065,6 +4065,7 @@ class TestSuiteDatasets:
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
             sort_by=None,
+            user_id=owner.id,
         )
         assert response.status_code == 200
         assert response.json() == {
@@ -4197,6 +4198,7 @@ class TestSuiteDatasets:
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
             sort_by=None,
+            user_id=owner.id,
         )
 
     @pytest.mark.parametrize(
@@ -4326,6 +4328,7 @@ class TestSuiteDatasets:
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
             sort_by=expected_sorts_by,
+            user_id=owner.id,
         )
 
     async def test_search_current_user_dataset_records_with_sort_by_with_wrong_sort_order_value(
@@ -4418,7 +4421,6 @@ class TestSuiteDatasets:
         )
 
         query_json = {"query": {"text": {"q": "Hello", "field": "input"}}}
-        params = [("include", include) for include in includes]
         expected = {
             "items": [
                 {
@@ -4526,6 +4528,7 @@ class TestSuiteDatasets:
             user_response_status_filter=None,
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
+            user_id=owner.id,
         )
 
     async def test_search_current_user_dataset_records_with_include_vectors(
@@ -4735,6 +4738,7 @@ class TestSuiteDatasets:
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
             sort_by=None,
+            user_id=owner.id,
         )
         assert response.status_code == 200
 
@@ -4967,6 +4971,7 @@ class TestSuiteDatasets:
             offset=0,
             limit=5,
             sort_by=None,
+            user_id=owner.id,
         )
         assert response.status_code == 200
         response_json = response.json()

--- a/tests/unit/api/v1/test_list_dataset_records.py
+++ b/tests/unit/api/v1/test_list_dataset_records.py
@@ -1231,7 +1231,8 @@ class TestSuiteListDatasetRecords:
             user_response_status_filter=None,
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
-            sort_by=[SortBy(field=RecordSortField.inserted_at)],
+            sort_by=None,
+            user_id=owner.id,
         )
 
     @pytest.mark.skip(reason="Factory integration with search engine")
@@ -1344,6 +1345,7 @@ class TestSuiteListDatasetRecords:
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
             sort_by=expected_sorts_by,
+            user_id=owner.id,
         )
 
     async def test_list_current_user_dataset_records_with_sort_by_with_wrong_sort_order_value(

--- a/tests/unit/search_engine/test_commons.py
+++ b/tests/unit/search_engine/test_commons.py
@@ -768,13 +768,12 @@ class TestBaseElasticAndOpenSearchEngine:
         offset: int,
         limit: int,
     ):
+        all_results = await search_engine.search(dataset_for_pagination, query="documents", offset=0, limit=100)
         results = await search_engine.search(dataset_for_pagination, query="documents", offset=offset, limit=limit)
 
         assert len(results.items) == min(len(dataset_for_pagination.records) - offset, limit)
         assert results.total == 100
-
-        records = sorted(dataset_for_pagination.records, key=lambda r: r.id)
-        assert [record.id for record in records[offset : offset + limit]] == [item.record_id for item in results.items]
+        assert all_results.items[offset : offset + limit] == results.items
 
     @pytest.mark.parametrize(
         ("sort_by"),


### PR DESCRIPTION
# Description

This PR updates the `search` method of the `SearchEngine` to sort the records for each user in a different way using the [`random_score`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-random) function and the user id as seed for this function to make the sort deterministic between user sessions. In addition, the default sort of the records using the `inserted_at` field in ascending order has been removed.

The affected endpoints by this change are `GET /api/v1/me/datasets/:dataset_id/records` and `GET /api/v1/me/datasets/:dataset_id/records/search`.

## Missing

If we finally decide to have this feature as default in the server, then before merging:

- [ ] Add unit tests using more than one user to check that the sorting of the records is different
- [ ] Add this change in the CHANGELOG.md

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

Change is already being used in https://huggingface.co/spaces/DIBT/prompt-collective

Apart from that, created several users, use them to list the records with the endpoints `GET /api/v1/me/datasets/records` and check that the retrieved records are in different order for all the users.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
