### PR TITLE
[WIP] feat: using user `id` for index responses in search indexes

### DIFF
--- a/tests/unit/search_engine/test_commons.py
+++ b/tests/unit/search_engine/test_commons.py
@@ -1029,7 +1029,7 @@ class TestBaseElasticAndOpenSearchEngine:
         results = opensearch.get(index=index_name, id=record.id)
 
         assert results["_source"]["responses"] == {
-            response.user.username: {
+            f"{response.user.id}": {
                 "values": {question.name: "test"},
                 "status": response.status.value,
             }
@@ -1039,7 +1039,7 @@ class TestBaseElasticAndOpenSearchEngine:
         assert index["mappings"]["properties"]["responses"] == {
             "dynamic": "true",
             "properties": {
-                response.user.username: {
+                f"{response.user.id}": {
                     "properties": {
                         "status": {"type": "keyword", "copy_to": [ALL_RESPONSES_STATUSES_FIELD]},
                         "values": {"properties": {question.name: {"index": False, "type": "text"}}},
@@ -1067,7 +1067,7 @@ class TestBaseElasticAndOpenSearchEngine:
 
         results = opensearch.get(index=index_name, id=record.id)
         assert results["_source"]["responses"] == {
-            response.user.username: {
+            str(response.user.id): {
                 "values": {question.name: "test"},
                 "status": response.status.value,
             }
@@ -1312,7 +1312,7 @@ class TestBaseElasticAndOpenSearchEngine:
         another_user = await UserFactory.create()
 
         for record in records:
-            users_responses = {f"{another_user.username}.status": status.value}
+            users_responses = {f"{another_user.id}.status": status.value}
             if user:
-                users_responses.update({f"{user.username}.status": status.value})
+                users_responses.update({f"{user.id}.status": status.value})
             opensearch.update(index_name, id=record.id, body={"doc": {"responses": users_responses}})


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR changes the way record responses are indexed for search, using the user `id` attribute instead of `username`.

>[!NOTE]
> The search index reindex command must be launched to refresh changes for existing datasets.

Closes https://github.com/argilla-io/argilla/issues/4586

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tested locally

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
