### PR TITLE
remove backward compatibility with argilla local auth  env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ These are the section headers that we use:
 - Changed indexing responses for search to use user `id` instead of `username`. **[Reindex needed](https://docs.argilla.io/en/latest/getting_started/installation/configurations/database_migrations.html#feedback-datasets)** ([#26](https://github.com/argilla-io/argilla-server/pull/26))
 - Changed search index mappings definition to optimize the number of fields. **[Reindex needed](https://docs.argilla.io/en/latest/getting_started/installation/configurations/database_migrations.html#feedback-datasets)** ([#31](https://github.com/argilla-io/argilla-server/pull/31))
 
+### Removed
+
+- Removed `ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES` environment variable. ([#38](https://github.com/argilla-io/argilla-server/pull/38))
+- Removed `ARGILLA_LOCAL_AUTH_ALGORITHM` environment variable. ([#38](https://github.com/argilla-io/argilla-server/pull/38))
+- Removed `ARGILLA_LOCAL_AUTH_SECRET_KEY` environment variable. ([#38](https://github.com/argilla-io/argilla-server/pull/38))
+
 ### Fixed
 
 - Max size parameter for getting the metadata property metrics is currently set as 2^14(=12) instead of 2 ** 14 ([#30](https://github.com/argilla-io/argilla-server/pull/30)) ([v1.24-fix](https://github.com/bharath97-git/argilla-server/releases/tag/v1.24-fix))

--- a/src/argilla_server/security/settings.py
+++ b/src/argilla_server/security/settings.py
@@ -52,19 +52,6 @@ class Settings(BaseSettings):
         super().__init__(**kwargs)
         self._oauth_settings = None
 
-    @validator("token_expiration", always=True)
-    def default_token_expiration(cls, v, values, **kwargs) -> int:
-        if "token_expiration" in values:
-            return v
-
-        # This is a backwards compatibility hack to support the old env variable and
-        # it will be removed in version 1.25.0. See https://github.com/argilla-io/argilla/issues/4542
-        expiration_in_minutes = os.getenv("ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES")
-        if expiration_in_minutes is not None:
-            return int(expiration_in_minutes) * 60
-
-        return v
-
     @property
     def oauth(self) -> "OAuth2Settings":
         """Return the oauth settings"""
@@ -82,19 +69,6 @@ class Settings(BaseSettings):
 
     class Config:
         env_prefix = "ARGILLA_AUTH_"
-
-        fields = {
-            # Support for old local auth env variables.
-            # It will be removed in version 1.25.0 (See https://github.com/argilla-io/argilla/issues/4542)
-            "algorithm": {"env": ["ARGILLA_LOCAL_AUTH_ALGORITHM", f"{env_prefix}ALGORITHM"]},
-            "secret_key": {"env": ["ARGILLA_LOCAL_AUTH_SECRET_KEY", f"{env_prefix}SECRET_KEY"]},
-            "token_expiration_in_minutes": {
-                "env": [
-                    "ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES",
-                    f"{env_prefix}TOKEN_EXPIRATION_IN_MINUTES",
-                ]
-            },
-        }
 
 
 settings = Settings()

--- a/tests/unit/security/test_settings.py
+++ b/tests/unit/security/test_settings.py
@@ -58,5 +58,3 @@ def test_configure_oauth_cfg():
         settings = Settings()
 
         assert settings.oauth_cfg == oauth_cfg
-
-

--- a/tests/unit/security/test_settings.py
+++ b/tests/unit/security/test_settings.py
@@ -60,29 +60,3 @@ def test_configure_oauth_cfg():
         assert settings.oauth_cfg == oauth_cfg
 
 
-def test_configure_algorithm_with_old_env_name():
-    algorithm = "old_mock-algorithm"
-    with mock.patch.dict(os.environ, {"ARGILLA_LOCAL_AUTH_ALGORITHM": algorithm}):
-        settings = Settings()
-
-        assert settings.algorithm == algorithm
-
-
-# TODO: remove this test when ARGILLA_LOCAL_AUTH_SECRET_KEY will be removed
-def test_configure_secret_key_with_old_env_name():
-    secret_key = "old_mock-secret-key"
-    with mock.patch.dict(os.environ, {"ARGILLA_LOCAL_AUTH_SECRET_KEY": secret_key}):
-        settings = Settings()
-
-        assert settings.secret_key == secret_key
-
-
-# TODO: remove this test when ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES will be removed
-def test_configure_token_expiration_in_minutes():
-    token_expiration_in_minutes = 30
-    with mock.patch.dict(
-        os.environ, {"ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES": str(token_expiration_in_minutes)}
-    ):
-        settings = Settings()
-
-        assert settings.token_expiration == token_expiration_in_minutes * 60


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR removes support for old `ARGILLA_LOCAL_AUTH_*` environment variables. 

Closes https://github.com/argilla-io/argilla/issues/4542

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
