### PR TITLE
feat: update span questions

### DIFF
--- a/src/argilla_server/apis/v1/handlers/suggestions.py
+++ b/src/argilla_server/apis/v1/handlers/suggestions.py
@@ -35,6 +35,7 @@ async def _get_suggestion(db: "AsyncSession", suggestion_id: UUID) -> Suggestion
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Suggestion with id `{suggestion_id}` not found",
         )
+
     return suggestion
 
 

--- a/src/argilla_server/contexts/questions.py
+++ b/src/argilla_server/contexts/questions.py
@@ -106,6 +106,11 @@ def _validate_question_before_create(dataset: Dataset, question_create: Question
         _validate_span_question_settings_before_create(dataset, question_create.settings)
 
 
+def _validate_question_before_update(question: Question, question_update: QuestionUpdate) -> None:
+    if question_update.settings:
+        _validate_question_settings(question.parsed_settings, question_update.settings)
+
+
 def _validate_span_question_settings_before_create(
     dataset: Dataset, span_question_settings_create: SpanQuestionSettingsCreate
 ) -> None:
@@ -140,8 +145,7 @@ async def update_question(db: AsyncSession, question_id: UUID, question_update: 
 
     await authorize(current_user, QuestionPolicyV1.update(question))
 
-    if question_update.settings:
-        _validate_question_settings(question.parsed_settings, question_update.settings)
+    _validate_question_before_update(question, question_update)
 
     params = question_update.dict(exclude_unset=True)
     return await question.update(db, **params)

--- a/src/argilla_server/contexts/questions.py
+++ b/src/argilla_server/contexts/questions.py
@@ -79,7 +79,7 @@ def _validate_question_settings(
 ) -> None:
     _validate_settings_type(question_settings, question_update_settings)
 
-    if question_settings.type in [QuestionType.label_selection, QuestionType.multi_label_selection]:
+    if question_settings.type in [QuestionType.label_selection, QuestionType.multi_label_selection, QuestionType.span]:
         _validate_label_options(question_settings, question_update_settings)
 
 

--- a/src/argilla_server/schemas/v1/questions.py
+++ b/src/argilla_server/schemas/v1/questions.py
@@ -145,6 +145,11 @@ class RankingQuestionSettingsUpdate(UpdateSchema):
     type: Literal[QuestionType.ranking]
 
 
+class SpanQuestionSettingsUpdate(UpdateSchema):
+    type: Literal[QuestionType.span]
+    options: Optional[conlist(item_type=OptionSettings)]
+
+
 QuestionSettingsUpdate = Annotated[
     Union[
         TextQuestionSettingsUpdate,
@@ -152,6 +157,7 @@ QuestionSettingsUpdate = Annotated[
         LabelSelectionSettingsUpdate,
         MultiLabelSelectionQuestionSettingsUpdate,
         RankingQuestionSettingsUpdate,
+        SpanQuestionSettingsUpdate,
     ],
     Field(..., discriminator="type"),
 ]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -376,6 +376,8 @@ class SpanQuestionFactory(QuestionFactory):
             {"value": "label-b", "text": "Label B", "description": "Label B description"},
             {"value": "label-c", "text": "Label C", "description": "Label C description"},
         ],
+        "allow_overlapping": False,
+        "allow_character_annotation": True,
     }
 
 

--- a/tests/unit/api/v1/test_questions.py
+++ b/tests/unit/api/v1/test_questions.py
@@ -28,6 +28,7 @@ from tests.factories import (
     MultiLabelSelectionQuestionFactory,
     RankingQuestionFactory,
     RatingQuestionFactory,
+    SpanQuestionFactory,
     TextQuestionFactory,
     UserFactory,
 )
@@ -177,6 +178,31 @@ if TYPE_CHECKING:
                 ],
             },
         ),
+        (
+            SpanQuestionFactory,
+            {
+                "settings": {
+                    "type": "span",
+                    "field": "field-a",
+                    "options": [
+                        {"value": "label-b", "text": "Label B", "description": "Label B description"},
+                        {"value": "label-a", "text": "Label A", "description": "Label A description"},
+                        {"value": "label-c", "text": "Label C", "description": "Label C description"},
+                    ],
+                }
+            },
+            {
+                "type": "span",
+                "field": "field-a",
+                "options": [
+                    {"value": "label-b", "text": "Label B", "description": "Label B description"},
+                    {"value": "label-a", "text": "Label A", "description": "Label A description"},
+                    {"value": "label-c", "text": "Label C", "description": "Label C description"},
+                ],
+                "allow_overlapping": False,
+                "allow_character_annotation": True,
+            },
+        ),
     ],
 )
 @pytest.mark.parametrize("role", [UserRole.owner])
@@ -213,6 +239,7 @@ async def test_update_question(
     }
 
     question = await db.get(Question, question.id)
+
     assert question.title == title
     assert question.description == description
     assert question.settings == expected_settings
@@ -318,6 +345,33 @@ async def test_update_question_with_invalid_description(
                         {"value": "undefined-option-01", "text": "Undefined option"},
                         {"value": "undefined-option-02", "text": "Undefined option"},
                         {"value": "undefined-option-03", "text": "Undefined option"},
+                    ],
+                }
+            },
+        ),
+        (
+            SpanQuestionFactory,
+            {
+                "settings": {
+                    "type": "span",
+                    "field": "field-a",
+                    "options": [
+                        {"value": "label-b", "text": "Label B", "description": "Label B description"},
+                        {"value": "label-c", "text": "Label C", "description": "Label C description"},
+                    ],
+                }
+            },
+        ),
+        (
+            SpanQuestionFactory,
+            {
+                "settings": {
+                    "type": "span",
+                    "field": "field-a",
+                    "options": [
+                        {"value": "label-a", "text": "Label A", "description": "Label A description"},
+                        {"value": "label-b", "text": "Label B", "description": "Label B description"},
+                        {"value": "label-d", "text": "Label D", "description": "Label D description"},
                     ],
                 }
             },


### PR DESCRIPTION
# Description

This PR add changes so span questions can be updated and labels on settings reorder. The labels can not be changed only reordered as we are already doing for label and multi label questions.

Closes #49 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)