### PR TITLE
feat: add additional validations for span responses and suggestions

### DIFF
--- a/src/argilla_server/contexts/datasets.py
+++ b/src/argilla_server/contexts/datasets.py
@@ -655,7 +655,9 @@ async def _build_record_responses(
     for idx, response_create in enumerate(responses_create):
         try:
             cache = await validate_user_exists(db, response_create.user_id, cache)
-            _validate_response_values(record, values=response_create.values, status=response_create.status)
+            _validate_response_values(
+                record, response_values=response_create.values, response_status=response_create.status
+            )
 
             responses.append(
                 Response(
@@ -976,7 +978,7 @@ async def count_responses_by_dataset_id_and_user_id(
 async def create_response(
     db: "AsyncSession", search_engine: SearchEngine, record: Record, user: User, response_create: ResponseCreate
 ) -> Response:
-    _validate_response_values(record, values=response_create.values, status=response_create.status)
+    _validate_response_values(record, response_values=response_create.values, response_status=response_create.status)
 
     async with db.begin_nested():
         response = await Response.create(
@@ -1000,7 +1002,9 @@ async def create_response(
 async def update_response(
     db: "AsyncSession", search_engine: SearchEngine, response: Response, response_update: ResponseUpdate
 ):
-    _validate_response_values(response.record, values=response_update.values, status=response_update.status)
+    _validate_response_values(
+        response.record, response_values=response_update.values, response_status=response_update.status
+    )
 
     async with db.begin_nested():
         response = await response.update(
@@ -1023,7 +1027,7 @@ async def update_response(
 async def upsert_response(
     db: "AsyncSession", search_engine: SearchEngine, record: Record, user: User, response_upsert: ResponseUpsert
 ) -> Response:
-    _validate_response_values(record, values=response_upsert.values, status=response_upsert.status)
+    _validate_response_values(record, response_values=response_upsert.values, response_status=response_upsert.status)
 
     schema = {
         "values": jsonable_encoder(response_upsert.values),
@@ -1063,29 +1067,53 @@ async def delete_response(db: "AsyncSession", search_engine: SearchEngine, respo
 
 def _validate_response_values(
     record: Record,
-    values: Union[Dict[str, ResponseValueCreate], Dict[str, ResponseValueUpdate], None],
-    status: ResponseStatus,
+    response_values: Union[Dict[str, ResponseValueCreate], Dict[str, ResponseValueUpdate], None],
+    response_status: ResponseStatus,
 ):
-    if not values:
-        if status not in [ResponseStatus.discarded, ResponseStatus.draft]:
+    if not response_values:
+        if response_status not in [ResponseStatus.discarded, ResponseStatus.draft]:
             raise ValueError("missing response values")
 
         return
 
-    values_copy = copy.copy(values)
+    response_values_copy = copy.copy(response_values)
     for question in record.dataset.questions:
         if (
             question.required
-            and status == ResponseStatus.submitted
-            and not (question.name in values and values_copy.get(question.name))
+            and response_status == ResponseStatus.submitted
+            and not (question.name in response_values and response_values_copy.get(question.name))
         ):
             raise ValueError(f"missing question with name={question.name}")
 
-        if question_response := values_copy.pop(question.name, None):
-            question.parsed_settings.check_response(question_response, status)
+        if question_response := response_values_copy.pop(question.name, None):
+            question_parsed_settings = question.parsed_settings
 
-    if values_copy:
-        raise ValueError(f"found responses for non configured questions: {list(values_copy.keys())!r}")
+            question_parsed_settings.check_response(question_response, response_status)
+
+            if question.is_span:
+                field_name = question_parsed_settings.field
+
+                if field_name not in record.fields:
+                    raise ValueError(
+                        f"response for span question `{question.name}` requires record to have field `{field_name}`"
+                    )
+
+                from argilla_server.models.questions import SpanQuestionResponseValue
+
+                record_field_len = len(record.fields[field_name])
+                for response_value_item in SpanQuestionResponseValue.parse_obj(question_response).value:
+                    if response_value_item.start > (record_field_len - 1):
+                        raise ValueError(
+                            f"span question response value `start` must have a value lower than record field `{field_name}` length that is `{record_field_len}`"
+                        )
+
+                    if response_value_item.end > record_field_len:
+                        raise ValueError(
+                            f"span question response value `end` must have a value lower or equal than record field `{field_name}` length that is `{record_field_len}`"
+                        )
+
+    if response_values_copy:
+        raise ValueError(f"found responses for non configured questions: {list(response_values_copy.keys())!r}")
 
 
 def _validate_record_fields(dataset: Dataset, fields: Dict[str, Any]):

--- a/src/argilla_server/models/database.py
+++ b/src/argilla_server/models/database.py
@@ -246,6 +246,10 @@ class Question(DatabaseModel):
         return parse_obj_as(QuestionSettings, self.settings)
 
     @property
+    def is_span(self) -> bool:
+        return self.type == QuestionType.span
+
+    @property
     def type(self) -> QuestionType:
         return QuestionType(self.settings["type"])
 

--- a/src/argilla_server/models/database.py
+++ b/src/argilla_server/models/database.py
@@ -246,10 +246,6 @@ class Question(DatabaseModel):
         return parse_obj_as(QuestionSettings, self.settings)
 
     @property
-    def is_span(self) -> bool:
-        return self.type == QuestionType.span
-
-    @property
     def type(self) -> QuestionType:
         return QuestionType(self.settings["type"])
 

--- a/src/argilla_server/models/questions.py
+++ b/src/argilla_server/models/questions.py
@@ -164,7 +164,7 @@ class SpanQuestionResponseValueItem(BaseModel):
         start, end = values.get("start"), values.get("end")
 
         if start is not None and end is not None and end <= start:
-            raise ValueError("Span question response value 'end' must have a value greater than 'start'")
+            raise ValueError("span question response value 'end' must have a value greater than 'start'")
 
         return values
 
@@ -175,11 +175,12 @@ class SpanQuestionResponseValue(BaseModel):
 
 class SpanQuestionSettings(BaseQuestionSettings):
     type: Literal[QuestionType.span]
+    field: str
     options: List[ValueTextQuestionSettingsOption]
 
     def check_response(self, response: ResponseValue, status: Optional[ResponseStatus] = None):
         if not isinstance(response.value, list):
-            raise ValueError(f"This Span question expects a list of values, found {type(response.value)}")
+            raise ValueError(f"this span question expects a list of values, found {type(response.value)}")
 
         span_question_response_value = self._parse_response_value(response)
         self._check_response_labels(span_question_response_value)
@@ -193,7 +194,7 @@ class SpanQuestionSettings(BaseQuestionSettings):
         for value_item in span_question_response_value.value:
             if not value_item.label in labels:
                 raise ValueError(
-                    f"Undefined label '{value_item.label}' for span question.\nValid labels are: {labels!r}"
+                    f"undefined label '{value_item.label}' for span question.\nValid labels are: {labels!r}"
                 )
 
 

--- a/tests/unit/api/v1/records/test_create_record_response.py
+++ b/tests/unit/api/v1/records/test_create_record_response.py
@@ -120,7 +120,7 @@ class TestCreateRecordResponse:
             "updated_at": datetime.fromisoformat(response_json["updated_at"]).isoformat(),
         }
 
-    async def test_create_record_response_for_span_question_with_record_not_providing_required_response_field(
+    async def test_create_record_response_for_span_question_with_record_not_providing_required_field(
         self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
@@ -145,9 +145,7 @@ class TestCreateRecordResponse:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": "response for span question `span-question` requires record to have field `field-a`"
-        }
+        assert response.json() == {"detail": "span question requires record to have field `field-a`"}
 
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 

--- a/tests/unit/api/v1/records/test_create_record_response.py
+++ b/tests/unit/api/v1/records/test_create_record_response.py
@@ -22,7 +22,7 @@ from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.factories import DatasetFactory, RecordFactory, SpanQuestionFactory, TextQuestionFactory
+from tests.factories import DatasetFactory, RecordFactory, SpanQuestionFactory
 
 
 @pytest.mark.asyncio
@@ -37,7 +37,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -47,8 +47,8 @@ class TestCreateRecordResponse:
                     "span-question": {
                         "value": [
                             {"label": "label-a", "start": 0, "end": 1},
-                            {"label": "label-b", "start": 24, "end": 32},
-                            {"label": "label-c", "start": 32, "end": 45},
+                            {"label": "label-b", "start": 2, "end": 3},
+                            {"label": "label-c", "start": 4, "end": 5},
                         ],
                     },
                 },
@@ -67,8 +67,8 @@ class TestCreateRecordResponse:
                 "span-question": {
                     "value": [
                         {"label": "label-a", "start": 0, "end": 1},
-                        {"label": "label-b", "start": 24, "end": 32},
-                        {"label": "label-c", "start": 32, "end": 45},
+                        {"label": "label-b", "start": 2, "end": 3},
+                        {"label": "label-c", "start": 4, "end": 5},
                     ],
                 },
             },
@@ -86,7 +86,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -120,14 +120,14 @@ class TestCreateRecordResponse:
             "updated_at": datetime.fromisoformat(response_json["updated_at"]).isoformat(),
         }
 
-    async def test_create_record_response_for_span_question_with_invalid_value(
+    async def test_create_record_response_for_span_question_with_record_not_providing_required_response_field(
         self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"other-field": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -136,7 +136,38 @@ class TestCreateRecordResponse:
                 "values": {
                     "span-question": {
                         "value": [
-                            {"label": "label-a", "start": 0, "end": 12},
+                            {"label": "label-a", "start": 0, "end": 1},
+                        ],
+                    },
+                },
+                "status": ResponseStatusFilter.submitted,
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "response for span question `span-question` requires record to have field `field-a`"
+        }
+
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+
+    async def test_create_record_response_for_span_question_with_invalid_value(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        await SpanQuestionFactory.create(name="span-question", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
+
+        response = await async_client.post(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "values": {
+                    "span-question": {
+                        "value": [
+                            {"label": "label-a", "start": 0, "end": 1},
                             {"invalid": "value"},
                         ],
                     },
@@ -148,6 +179,64 @@ class TestCreateRecordResponse:
         assert response.status_code == 422
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
+    async def test_create_record_response_for_span_question_with_start_greater_than_expected(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        await SpanQuestionFactory.create(name="span-question", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
+
+        response = await async_client.post(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "values": {
+                    "span-question": {
+                        "value": [{"label": "label-a", "start": 5, "end": 6}],
+                    },
+                },
+                "status": ResponseStatusFilter.submitted,
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "span question response value `start` must have a value lower than record field `field-a` length that is `5`"
+        }
+
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+
+    async def test_create_record_response_for_span_question_with_end_greater_than_expected(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        await SpanQuestionFactory.create(name="span-question", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
+
+        response = await async_client.post(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "values": {
+                    "span-question": {
+                        "value": [{"label": "label-a", "start": 4, "end": 6}],
+                    },
+                },
+                "status": ResponseStatusFilter.submitted,
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "span question response value `end` must have a value lower or equal than record field `field-a` length that is `5`"
+        }
+
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+
     async def test_create_record_response_for_span_question_with_invalid_start(
         self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
     ):
@@ -155,7 +244,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -182,7 +271,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -209,7 +298,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -218,7 +307,7 @@ class TestCreateRecordResponse:
                 "values": {
                     "span-question": {
                         "value": [
-                            {"label": "label-a", "start": 42, "end": 42},
+                            {"label": "label-a", "start": 1, "end": 1},
                         ],
                     },
                 },
@@ -236,7 +325,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -245,7 +334,7 @@ class TestCreateRecordResponse:
                 "values": {
                     "span-question": {
                         "value": [
-                            {"label": "label-a", "start": 42, "end": 41},
+                            {"label": "label-a", "start": 3, "end": 2},
                         ],
                     },
                 },
@@ -263,7 +352,7 @@ class TestCreateRecordResponse:
 
         await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.post(
             self.url(record.id),
@@ -272,7 +361,7 @@ class TestCreateRecordResponse:
                 "values": {
                     "span-question": {
                         "value": [
-                            {"label": "label-non-existent", "start": 32, "end": 45},
+                            {"label": "label-non-existent", "start": 1, "end": 2},
                         ],
                     },
                 },
@@ -282,7 +371,7 @@ class TestCreateRecordResponse:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": "Undefined label 'label-non-existent' for span question.\nValid labels are: ['label-a', 'label-b', 'label-c']"
+            "detail": "undefined label 'label-non-existent' for span question.\nValid labels are: ['label-a', 'label-b', 'label-c']"
         }
 
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 0

--- a/tests/unit/api/v1/records/test_upsert_suggestion.py
+++ b/tests/unit/api/v1/records/test_upsert_suggestion.py
@@ -141,7 +141,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -151,8 +151,8 @@ class TestUpsertSuggestion:
                 "type": SuggestionType.model,
                 "value": [
                     {"label": "label-a", "start": 0, "end": 1},
-                    {"label": "label-b", "start": 24, "end": 32},
-                    {"label": "label-c", "start": 32, "end": 45},
+                    {"label": "label-b", "start": 2, "end": 3},
+                    {"label": "label-c", "start": 4, "end": 5},
                 ],
             },
         )
@@ -168,8 +168,8 @@ class TestUpsertSuggestion:
             "type": SuggestionType.model,
             "value": [
                 {"label": "label-a", "start": 0, "end": 1},
-                {"label": "label-b", "start": 24, "end": 32},
-                {"label": "label-c", "start": 32, "end": 45},
+                {"label": "label-b", "start": 2, "end": 3},
+                {"label": "label-c", "start": 4, "end": 5},
             ],
             "agent": None,
             "score": None,
@@ -182,7 +182,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -208,14 +208,14 @@ class TestUpsertSuggestion:
             "score": None,
         }
 
-    async def test_upsert_suggestion_for_span_question_with_invalid_value(
+    async def test_upsert_suggestion_for_span_question_with_record_not_providing_required_field(
         self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"other-field": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -224,13 +224,95 @@ class TestUpsertSuggestion:
                 "question_id": str(span_question.id),
                 "type": SuggestionType.model,
                 "value": [
-                    {"label": "label-a", "start": 0, "end": 12},
+                    {"label": "label-a", "start": 0, "end": 1},
+                ],
+            },
+        )
+
+        assert response.status_code == 422, response.json()
+        assert response.json() == {"detail": "span question requires record to have field `field-a`"}
+
+        assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 0
+
+    async def test_upsert_suggestion_for_span_question_with_invalid_value(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
+
+        response = await async_client.put(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(span_question.id),
+                "type": SuggestionType.model,
+                "value": [
+                    {"label": "label-a", "start": 0, "end": 1},
                     {"invalid": "value"},
                 ],
             },
         )
 
         assert response.status_code == 422
+        assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 0
+
+    async def test_upsert_suggestion_for_span_question_with_start_greater_than_expected(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
+
+        response = await async_client.put(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(span_question.id),
+                "type": SuggestionType.model,
+                "value": [
+                    {"label": "label-a", "start": 5, "end": 6},
+                ],
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "span question response value `start` must have a value lower than record field `field-a` length that is `5`"
+        }
+
+        assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 0
+
+    async def test_upsert_suggestion_for_span_question_with_end_greater_than_expected(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
+
+        response = await async_client.put(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(span_question.id),
+                "type": SuggestionType.model,
+                "value": [
+                    {"label": "label-a", "start": 4, "end": 6},
+                ],
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "span question response value `end` must have a value lower or equal than record field `field-a` length that is `5`"
+        }
+
         assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 0
 
     async def test_upsert_suggestion_for_span_question_with_invalid_start(
@@ -240,7 +322,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -264,7 +346,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -288,7 +370,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -297,7 +379,7 @@ class TestUpsertSuggestion:
                 "question_id": str(span_question.id),
                 "type": SuggestionType.model,
                 "value": [
-                    {"label": "label-a", "start": 42, "end": 42},
+                    {"label": "label-a", "start": 1, "end": 1},
                 ],
             },
         )
@@ -312,7 +394,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -321,7 +403,7 @@ class TestUpsertSuggestion:
                 "question_id": str(span_question.id),
                 "type": SuggestionType.model,
                 "value": [
-                    {"label": "label-a", "start": 42, "end": 41},
+                    {"label": "label-a", "start": 3, "end": 2},
                 ],
             },
         )
@@ -336,7 +418,7 @@ class TestUpsertSuggestion:
 
         span_question = await SpanQuestionFactory.create(name="span-question", dataset=dataset)
 
-        record = await RecordFactory.create(dataset=dataset)
+        record = await RecordFactory.create(fields={"field-a": "Hello"}, dataset=dataset)
 
         response = await async_client.put(
             self.url(record.id),
@@ -345,7 +427,7 @@ class TestUpsertSuggestion:
                 "question_id": str(span_question.id),
                 "type": SuggestionType.model,
                 "value": [
-                    {"label": "label-non-existent", "start": 32, "end": 45},
+                    {"label": "label-non-existent", "start": 1, "end": 2},
                 ],
             },
         )

--- a/tests/unit/api/v1/records/test_upsert_suggestion.py
+++ b/tests/unit/api/v1/records/test_upsert_suggestion.py
@@ -352,7 +352,7 @@ class TestUpsertSuggestion:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": "Undefined label 'label-non-existent' for span question.\nValid labels are: ['label-a', 'label-b', 'label-c']"
+            "detail": "undefined label 'label-non-existent' for span question.\nValid labels are: ['label-a', 'label-b', 'label-c']"
         }
 
         assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 0


### PR DESCRIPTION
# Description

This PR add additional validations for span responses and suggestions:
* Check that the required `field` to be annotated by the response or suggestion is present in the associated record.
* Check that annotation `start` attribute is lower than the length in characters of the associated record field.
* Check that annotation `end` attribute is lower or equal than the length in characters of the associated record field.

These validations are done in the `check_response` function present in `questions` models package.

Refs #45

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Adding new tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)