### PR TITLE
feat: add score to span suggestions

### DIFF
--- a/src/argilla_server/models/questions.py
+++ b/src/argilla_server/models/questions.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Generic, List, Literal, Optional, Protocol, TypeVa
 
 from argilla_server.enums import QuestionType, ResponseStatus
 from argilla_server.pydantic_v1 import BaseModel, Field, root_validator
+from argilla_server.schemas.v1.commons.suggestions import SuggestionScoreField
 
 try:
     from typing import Annotated
@@ -160,6 +161,10 @@ class SpanQuestionResponseValueItem(BaseModel):
     label: str
     start: int = Field(..., ge=0)
     end: int = Field(..., ge=1)
+    # NOTE: score field it's only used for suggestions and not for responses, right now we don't have a
+    # way to differentiate between the two so we are defining it here to validate suggestions where the field
+    # it's available.
+    score: SuggestionScoreField
 
     @root_validator(skip_on_failure=True)
     def check_start_and_end(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/argilla_server/schemas/v1/commons/__init__.py
+++ b/src/argilla_server/schemas/v1/commons/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla_server/schemas/v1/commons/suggestions.py
+++ b/src/argilla_server/schemas/v1/commons/suggestions.py
@@ -1,0 +1,32 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Annotated, Optional
+
+from argilla_server.pydantic_v1 import Field
+
+SUGGESTION_SCORE_GREATER_THAN_OR_EQUAL = 0
+SUGGESTION_SCORE_LESS_THAN_OR_EQUAL = 1
+
+# TODO: This field has been defined here because it's used by models questions file (aka check_responses) and to
+# avoid cyclical import errors. Once that we remove check_responses functionality we can move this field
+# again to be used in the necessary schema model.
+SuggestionScoreField = Annotated[
+    Optional[float],
+    Field(
+        ge=SUGGESTION_SCORE_GREATER_THAN_OR_EQUAL,
+        le=SUGGESTION_SCORE_LESS_THAN_OR_EQUAL,
+        description="The score assigned to the suggestion",
+    ),
+]

--- a/src/argilla_server/schemas/v1/suggestions.py
+++ b/src/argilla_server/schemas/v1/suggestions.py
@@ -13,19 +13,17 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Optional, Union
 from uuid import UUID
 
 from argilla_server.models import SuggestionType
 from argilla_server.pydantic_v1 import BaseModel, Field
+from argilla_server.schemas.v1.commons.suggestions import SuggestionScoreField
 from argilla_server.schemas.v1.questions import QuestionName
 
 AGENT_REGEX = r"^(?=.*[a-zA-Z0-9])[a-zA-Z0-9-_:\.\/\s]+$"
 AGENT_MIN_LENGTH = 1
 AGENT_MAX_LENGTH = 200
-
-SCORE_GREATER_THAN_OR_EQUAL = 0
-SCORE_LESS_THAN_OR_EQUAL = 1
 
 
 class SuggestionFilterScope(BaseModel):
@@ -77,9 +75,4 @@ class SuggestionCreate(BaseSuggestion):
         max_length=AGENT_MAX_LENGTH,
         description="Agent used to generate the suggestion",
     )
-    score: Optional[float] = Field(
-        None,
-        ge=SCORE_GREATER_THAN_OR_EQUAL,
-        le=SCORE_LESS_THAN_OR_EQUAL,
-        description="The score assigned to the suggestion",
-    )
+    score: SuggestionScoreField


### PR DESCRIPTION
# Description

This PR add a small addition to value items specified for responses and suggestions adding `score` field.

As we now the `check_response` implementation only validates so still any field specified in the value for responses and suggestions will be inserted in the database. Because of this we have some caveats:
* `score` using an integer like `1` will be store as `1` without being transformed to float.
* When `score` is not specified we will not store inside the JSON column `{..., "score": None}` instead `score` attribute will not be available.
* It's possible to specify `score` for responses not only suggestions.

Closes #55 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Adding new tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)