### PR TITLE
fix: allow fetch responses from deleted users

### DIFF
--- a/src/argilla_server/schemas/v1/responses.py
+++ b/src/argilla_server/schemas/v1/responses.py
@@ -49,7 +49,7 @@ class Response(BaseModel):
     values: Optional[Dict[str, ResponseValue]]
     status: ResponseStatus
     record_id: UUID
-    user_id: UUID
+    user_id: Optional[UUID] = None # Responses for delete users will have this field as None but still be present
     inserted_at: datetime
     updated_at: datetime
 

--- a/tests/unit/api/v1/test_records.py
+++ b/tests/unit/api/v1/test_records.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Callable, Type
+from typing import Awaitable, TYPE_CHECKING, Any, Callable, Type
 from unittest.mock import call
 from uuid import UUID, uuid4
 
@@ -21,7 +21,7 @@ import pytest
 from argilla_server.constants import API_KEY_HEADER_NAME
 from argilla_server.enums import ResponseStatus
 from argilla_server.models import Dataset, Record, Response, Suggestion, User, UserRole
-from argilla_server.search_engine import SearchEngine
+from argilla_server.search_engine import SearchEngine, SearchResponseItem, SearchResponses
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -922,7 +922,7 @@ class TestSuiteRecords:
         self,
         async_client: "AsyncClient",
         owner_auth_header: dict,
-        create_questions_func: Callable[["Dataset"], None],
+        create_questions_func: Callable[["Dataset"], Awaitable[None]],
         responses: dict,
         expected_error_msg: str,
     ):


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR allows returning records with deleted users' responses (user_id=None). This change will allow SDK admins to work with those responses.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tested locally

- [ ] Test A
- [ ] Test B

**Checklist**

- [X] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
