### PR TITLE
feat: add uniqueness field validation for span questions

### DIFF
--- a/src/argilla_server/apis/v1/handlers/datasets/questions.py
+++ b/src/argilla_server/apis/v1/handlers/datasets/questions.py
@@ -48,6 +48,8 @@ async def create_dataset_question(
     question_create: QuestionCreate,
     current_user: User = Security(auth.get_current_user),
 ):
+    # TODO: Review this flow since we're putting logic here that will be used internally by the context
+    #  Fields and questions are required to apply validations.
     dataset = await _get_dataset_or_raise(db, dataset_id, with_fields=True, with_questions=True)
 
     await authorize(current_user, DatasetPolicyV1.create_question(dataset))

--- a/src/argilla_server/apis/v1/handlers/datasets/questions.py
+++ b/src/argilla_server/apis/v1/handlers/datasets/questions.py
@@ -48,7 +48,7 @@ async def create_dataset_question(
     question_create: QuestionCreate,
     current_user: User = Security(auth.get_current_user),
 ):
-    dataset = await _get_dataset_or_raise(db, dataset_id, with_fields=True)
+    dataset = await _get_dataset_or_raise(db, dataset_id, with_fields=True, with_questions=True)
 
     await authorize(current_user, DatasetPolicyV1.create_question(dataset))
 

--- a/src/argilla_server/contexts/questions.py
+++ b/src/argilla_server/contexts/questions.py
@@ -120,6 +120,10 @@ def _validate_span_question_settings_before_create(
     if field not in field_names:
         raise ValueError(f"'{field}' is not a valid field name.\nValid field names are {field_names!r}")
 
+    for question in dataset.questions:
+        if question.type == QuestionType.span and field == question.parsed_settings.field:
+            raise ValueError(f"'{field}' is already used by span question with id '{question.id}'")
+
 
 async def create_question(db: AsyncSession, dataset: Dataset, question_create: QuestionCreate) -> Question:
     if dataset.is_ready:

--- a/tests/unit/api/v1/datasets/test_create_dataset_question.py
+++ b/tests/unit/api/v1/datasets/test_create_dataset_question.py
@@ -137,6 +137,4 @@ class TestCreateDatasetQuestion:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": f"'field-a' is already used by span question with id '{question.id}'"
-        }
+        assert response.json() == {"detail": f"'field-a' is already used by span question with id '{question.id}'"}

--- a/tests/unit/api/v1/datasets/test_create_dataset_question.py
+++ b/tests/unit/api/v1/datasets/test_create_dataset_question.py
@@ -110,7 +110,7 @@ class TestCreateDatasetQuestion:
 
         assert (await db.execute(select(func.count(Question.id)))).scalar() == 0
 
-    async def test_create_dataset_question_with_already_span_question_using_the_same_field(
+    async def test_create_dataset_question_with_other_span_question_using_the_same_field(
         self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()

--- a/tests/unit/api/v1/datasets/test_create_dataset_question.py
+++ b/tests/unit/api/v1/datasets/test_create_dataset_question.py
@@ -22,7 +22,7 @@ from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.factories import DatasetFactory, TextFieldFactory
+from tests.factories import DatasetFactory, SpanQuestionFactory, TextFieldFactory
 
 
 @pytest.mark.asyncio
@@ -109,3 +109,34 @@ class TestCreateDatasetQuestion:
         }
 
         assert (await db.execute(select(func.count(Question.id)))).scalar() == 0
+
+    async def test_create_dataset_question_with_already_span_question_using_the_same_field(
+        self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        question = await SpanQuestionFactory(dataset=dataset)
+
+        question_field = question.settings["field"]
+        await TextFieldFactory.create(name=question_field, dataset=dataset)
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "name": "new-question",
+                "title": "Title",
+                "settings": {
+                    "type": QuestionType.span,
+                    "field": question_field,
+                    "options": [
+                        {"value": "label-c", "text": "Label C", "description": "Label C description"},
+                        {"value": "label-d", "text": "Label D", "description": "Label D description"},
+                    ],
+                },
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": f"'field-a' is already used by span question with id '{question.id}'"
+        }


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds a server validation to avoid creating several span questions using the same field. 


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
