### PR TITLE
feat: add visible options parameter for span questions

### DIFF
--- a/src/argilla_server/contexts/questions.py
+++ b/src/argilla_server/contexts/questions.py
@@ -50,6 +50,7 @@ def _validate_settings_type(settings: QuestionSettings, settings_update: Questio
 
 
 def _validate_label_options(settings: LabelSelectionQuestionSettings, settings_update: LabelSelectionSettingsUpdate):
+    # TODO: Validate visible_options on update
     if settings_update.options is None:
         return
 
@@ -142,7 +143,9 @@ async def create_question(db: AsyncSession, dataset: Dataset, question_create: Q
     )
 
 
-async def update_question(db: AsyncSession, question_id: UUID, question_update: QuestionUpdate, current_user: User):
+async def update_question(
+    db: AsyncSession, question_id: UUID, question_update: QuestionUpdate, current_user: User
+) -> Question:
     question = await get_question_by_id(db, question_id)
     if not question:
         raise errors.NotFoundError()

--- a/src/argilla_server/schemas/v1/questions.py
+++ b/src/argilla_server/schemas/v1/questions.py
@@ -16,11 +16,8 @@ from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from argilla_server.models import QuestionType
-from argilla_server.models.database import Dataset
-from argilla_server.pydantic_v1 import BaseModel, Field, PositiveInt, conlist, constr, root_validator, validator
+from argilla_server.pydantic_v1 import BaseModel, Field, conlist, constr, root_validator, validator
 from argilla_server.schemas.base import UpdateSchema
 from argilla_server.schemas.v1.fields import FieldName
 
@@ -61,13 +58,68 @@ RATING_UPPER_VALUE_ALLOWED = 10
 
 SPAN_OPTIONS_MIN_ITEMS = 1
 SPAN_OPTIONS_MAX_ITEMS = 500
+SPAN_MIN_VISIBLE_OPTIONS = 3
 
 
+class UniqueValuesCheckerMixin(BaseModel):
+    @root_validator(skip_on_failure=True)
+    def check_unique_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        options = values.get("options", [])
+        seen = set()
+        duplicates = set()
+        for option in options:
+            if option.value in seen:
+                duplicates.add(option.value)
+            else:
+                seen.add(option.value)
+        if duplicates:
+            raise ValueError(f"Option values must be unique, found duplicates: {duplicates}")
+        return values
+
+
+# Option-based settings
+class OptionSettings(BaseModel):
+    value: str
+    text: str
+    description: Optional[str] = None
+
+
+class OptionSettingsCreate(BaseModel):
+    value: constr(
+        min_length=VALUE_TEXT_OPTION_VALUE_MIN_LENGTH,
+        max_length=VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
+    )
+    text: constr(
+        min_length=VALUE_TEXT_OPTION_TEXT_MIN_LENGTH,
+        max_length=VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
+    )
+    description: Optional[
+        constr(
+            min_length=VALUE_TEXT_OPTION_DESCRIPTION_MIN_LENGTH,
+            max_length=VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
+        )
+    ] = None
+
+
+# Text question
 class TextQuestionSettings(BaseModel):
     type: Literal[QuestionType.text]
     use_markdown: bool = False
 
 
+class TextQuestionSettingsCreate(BaseModel):
+    type: Literal[QuestionType.text]
+    use_markdown: bool = False
+
+
+class TextQuestionSettingsUpdate(UpdateSchema):
+    type: Literal[QuestionType.text]
+    use_markdown: Optional[bool]
+
+    __non_nullable_fields__ = {"use_markdown"}
+
+
+# Rating question
 class RatingQuestionSettingsOption(BaseModel):
     value: int
 
@@ -77,34 +129,149 @@ class RatingQuestionSettings(BaseModel):
     options: conlist(item_type=RatingQuestionSettingsOption)
 
 
-class OptionSettings(BaseModel):
-    value: str
-    text: str
-    description: Optional[str] = None
+class RatingQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.rating]
+    options: conlist(
+        item_type=RatingQuestionSettingsOption,
+        min_items=RATING_OPTIONS_MIN_ITEMS,
+        max_items=RATING_OPTIONS_MAX_ITEMS,
+    )
+
+    @validator("options")
+    def check_option_value_range(cls, options: List[RatingQuestionSettingsOption]):
+        """Validator to control all values are in allowed range 1 <= x <= 10"""
+        for option in options:
+            if not RATING_LOWER_VALUE_ALLOWED <= option.value <= RATING_UPPER_VALUE_ALLOWED:
+                raise ValueError(
+                    f"Option value {option.value!r} out of range "
+                    f"[{RATING_LOWER_VALUE_ALLOWED!r}, {RATING_UPPER_VALUE_ALLOWED!r}]"
+                )
+        return options
 
 
+class RatingQuestionSettingsUpdate(UpdateSchema):
+    type: Literal[QuestionType.rating]
+
+
+# Label selection question
 class LabelSelectionQuestionSettings(BaseModel):
     type: Literal[QuestionType.label_selection]
-    options: conlist(item_type=OptionSettings)
+    options: List[OptionSettings]
     visible_options: Optional[int] = None
 
 
+class LabelSelectionQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.label_selection]
+    options: conlist(
+        item_type=OptionSettingsCreate,
+        min_items=LABEL_SELECTION_OPTIONS_MIN_ITEMS,
+        max_items=LABEL_SELECTION_OPTIONS_MAX_ITEMS,
+    )
+    visible_options: Optional[int] = Field(None, ge=LABEL_SELECTION_MIN_VISIBLE_OPTIONS)
+
+    @root_validator(skip_on_failure=True)
+    def check_visible_options_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        visible_options = values.get("visible_options")
+        if visible_options is not None:
+            num_options = len(values["options"])
+            if visible_options > num_options:
+                raise ValueError(
+                    "The value for 'visible_options' must be less or equal to the number of items in 'options'"
+                    f" ({num_options})"
+                )
+
+        return values
+
+
+class LabelSelectionSettingsUpdate(UpdateSchema):
+    type: Literal[QuestionType.label_selection]
+    visible_options: Optional[int] = Field(None, ge=LABEL_SELECTION_MIN_VISIBLE_OPTIONS)
+    options: Optional[
+        conlist(
+            item_type=OptionSettings,
+            min_items=LABEL_SELECTION_OPTIONS_MIN_ITEMS,
+            max_items=LABEL_SELECTION_OPTIONS_MAX_ITEMS,
+        )
+    ]
+
+
+# Multi-label selection question
 class MultiLabelSelectionQuestionSettings(LabelSelectionQuestionSettings):
     type: Literal[QuestionType.multi_label_selection]
 
 
+class MultiLabelSelectionQuestionSettingsCreate(LabelSelectionQuestionSettingsCreate):
+    type: Literal[QuestionType.multi_label_selection]
+
+
+class MultiLabelSelectionQuestionSettingsUpdate(LabelSelectionSettingsUpdate):
+    type: Literal[QuestionType.multi_label_selection]
+
+
+# Ranking question
 class RankingQuestionSettings(BaseModel):
     type: Literal[QuestionType.ranking]
-    options: conlist(item_type=OptionSettings)
+    options: List[OptionSettings]
 
 
+class RankingQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.ranking]
+    options: conlist(
+        item_type=OptionSettingsCreate,
+        min_items=RANKING_OPTIONS_MIN_ITEMS,
+        max_items=RANKING_OPTIONS_MAX_ITEMS,
+    )
+
+
+class RankingQuestionSettingsUpdate(UpdateSchema):
+    type: Literal[QuestionType.ranking]
+
+
+# Span question
 class SpanQuestionSettings(BaseModel):
     type: Literal[QuestionType.span]
     field: str
-    options: conlist(item_type=OptionSettings)
+    options: List[OptionSettings]
+    visible_options: Optional[int] = None
     # These attributes are read-only for now
     allow_overlapping: bool = Field(default=False, description="Allow spans overlapping")
     allow_character_annotation: bool = Field(default=True, description="Allow character-level annotation")
+
+
+class SpanQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.span]
+    field: FieldName
+    options: conlist(
+        item_type=OptionSettingsCreate,
+        min_items=SPAN_OPTIONS_MIN_ITEMS,
+        max_items=SPAN_OPTIONS_MAX_ITEMS,
+    )
+    visible_options: Optional[int] = Field(None, ge=SPAN_MIN_VISIBLE_OPTIONS)
+
+    @root_validator(skip_on_failure=True)
+    def check_visible_options_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        visible_options = values.get("visible_options")
+        if visible_options is not None:
+            num_options = len(values["options"])
+            if visible_options > num_options:
+                raise ValueError(
+                    "The value for 'visible_options' must be less or equal to the number of items in 'options'"
+                    f" ({num_options})"
+                )
+
+        return values
+
+
+class SpanQuestionSettingsUpdate(UpdateSchema):
+    type: Literal[QuestionType.span]
+    options: Optional[
+        conlist(
+            item_type=OptionSettings,
+            min_items=SPAN_OPTIONS_MIN_ITEMS,
+            max_items=SPAN_OPTIONS_MAX_ITEMS,
+        )
+    ]
+    visible_options: Optional[int] = Field(None, ge=SPAN_MIN_VISIBLE_OPTIONS)
 
 
 QuestionSettings = Annotated[
@@ -115,49 +282,6 @@ QuestionSettings = Annotated[
         MultiLabelSelectionQuestionSettings,
         RankingQuestionSettings,
         SpanQuestionSettings,
-    ],
-    Field(..., discriminator="type"),
-]
-
-
-class TextQuestionSettingsUpdate(UpdateSchema):
-    type: Literal[QuestionType.text]
-    use_markdown: Optional[bool]
-
-    __non_nullable_fields__ = {"use_markdown"}
-
-
-class RatingQuestionSettingsUpdate(UpdateSchema):
-    type: Literal[QuestionType.rating]
-
-
-class LabelSelectionSettingsUpdate(UpdateSchema):
-    type: Literal[QuestionType.label_selection]
-    visible_options: Optional[PositiveInt]
-    options: Optional[conlist(item_type=OptionSettings)]
-
-
-class MultiLabelSelectionQuestionSettingsUpdate(LabelSelectionSettingsUpdate):
-    type: Literal[QuestionType.multi_label_selection]
-
-
-class RankingQuestionSettingsUpdate(UpdateSchema):
-    type: Literal[QuestionType.ranking]
-
-
-class SpanQuestionSettingsUpdate(UpdateSchema):
-    type: Literal[QuestionType.span]
-    options: Optional[conlist(item_type=OptionSettings)]
-
-
-QuestionSettingsUpdate = Annotated[
-    Union[
-        TextQuestionSettingsUpdate,
-        RatingQuestionSettingsUpdate,
-        LabelSelectionSettingsUpdate,
-        MultiLabelSelectionQuestionSettingsUpdate,
-        RankingQuestionSettingsUpdate,
-        SpanQuestionSettingsUpdate,
     ],
     Field(..., discriminator="type"),
 ]
@@ -191,110 +315,6 @@ QuestionDescription = Annotated[
 ]
 
 
-class UniqueValuesCheckerMixin(BaseModel):
-    @root_validator(skip_on_failure=True)
-    def check_unique_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        options = values.get("options", [])
-        seen = set()
-        duplicates = set()
-        for option in options:
-            if option.value in seen:
-                duplicates.add(option.value)
-            else:
-                seen.add(option.value)
-        if duplicates:
-            raise ValueError(f"Option values must be unique, found duplicates: {duplicates}")
-        return values
-
-
-class TextQuestionSettingsCreate(BaseModel):
-    type: Literal[QuestionType.text]
-    use_markdown: bool = False
-
-
-class RatingQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.rating]
-    options: conlist(
-        item_type=RatingQuestionSettingsOption,
-        min_items=RATING_OPTIONS_MIN_ITEMS,
-        max_items=RATING_OPTIONS_MAX_ITEMS,
-    )
-
-    @validator("options")
-    def check_option_value_range(cls, options: List[RatingQuestionSettingsOption]):
-        """Validator to control all values are in allowed range 1 <= x <= 10"""
-        for option in options:
-            if not RATING_LOWER_VALUE_ALLOWED <= option.value <= RATING_UPPER_VALUE_ALLOWED:
-                raise ValueError(
-                    f"Option value {option.value!r} out of range "
-                    f"[{RATING_LOWER_VALUE_ALLOWED!r}, {RATING_UPPER_VALUE_ALLOWED!r}]"
-                )
-        return options
-
-
-class OptionSettingsCreate(BaseModel):
-    value: constr(
-        min_length=VALUE_TEXT_OPTION_VALUE_MIN_LENGTH,
-        max_length=VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
-    )
-    text: constr(
-        min_length=VALUE_TEXT_OPTION_TEXT_MIN_LENGTH,
-        max_length=VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
-    )
-    description: Optional[
-        constr(
-            min_length=VALUE_TEXT_OPTION_DESCRIPTION_MIN_LENGTH,
-            max_length=VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
-        )
-    ] = None
-
-
-class LabelSelectionQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.label_selection]
-    options: conlist(
-        item_type=OptionSettingsCreate,
-        min_items=LABEL_SELECTION_OPTIONS_MIN_ITEMS,
-        max_items=LABEL_SELECTION_OPTIONS_MAX_ITEMS,
-    )
-    visible_options: Optional[int] = Field(None, ge=LABEL_SELECTION_MIN_VISIBLE_OPTIONS)
-
-    @root_validator(skip_on_failure=True)
-    def check_visible_options_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        visible_options = values.get("visible_options")
-        if visible_options is not None:
-            num_options = len(values["options"])
-            if visible_options > num_options:
-                raise ValueError(
-                    "The value for 'visible_options' must be less or equal to the number of items in 'options'"
-                    f" ({num_options})"
-                )
-
-        return values
-
-
-class MultiLabelSelectionQuestionSettingsCreate(LabelSelectionQuestionSettingsCreate):
-    type: Literal[QuestionType.multi_label_selection]
-
-
-class RankingQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.ranking]
-    options: conlist(
-        item_type=OptionSettingsCreate,
-        min_items=RANKING_OPTIONS_MIN_ITEMS,
-        max_items=RANKING_OPTIONS_MAX_ITEMS,
-    )
-
-
-class SpanQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.span]
-    field: FieldName
-    options: conlist(
-        item_type=OptionSettingsCreate,
-        min_items=SPAN_OPTIONS_MIN_ITEMS,
-        max_items=SPAN_OPTIONS_MAX_ITEMS,
-    )
-
-
 QuestionSettingsCreate = Annotated[
     Union[
         TextQuestionSettingsCreate,
@@ -305,6 +325,19 @@ QuestionSettingsCreate = Annotated[
         SpanQuestionSettingsCreate,
     ],
     Field(discriminator="type"),
+]
+
+
+QuestionSettingsUpdate = Annotated[
+    Union[
+        TextQuestionSettingsUpdate,
+        RatingQuestionSettingsUpdate,
+        LabelSelectionSettingsUpdate,
+        MultiLabelSelectionQuestionSettingsUpdate,
+        RankingQuestionSettingsUpdate,
+        SpanQuestionSettingsUpdate,
+    ],
+    Field(..., discriminator="type"),
 ]
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -371,6 +371,7 @@ class SpanQuestionFactory(QuestionFactory):
     settings = {
         "type": QuestionType.span.value,
         "field": "field-a",
+        "visible_options": None,
         "options": [
             {"value": "label-a", "text": "Label A", "description": "Label A description"},
             {"value": "label-b", "text": "Label B", "description": "Label B description"},

--- a/tests/unit/api/v1/datasets/test_questions.py
+++ b/tests/unit/api/v1/datasets/test_questions.py
@@ -156,6 +156,7 @@ class TestDatasetQuestions:
                 {
                     "type": "span",
                     "field": "field-a",
+                    "visible_options": None,
                     "options": [
                         {"value": "label-a", "text": "Label A", "description": None},
                         {"value": "label-b", "text": "Label B", "description": None},
@@ -165,6 +166,32 @@ class TestDatasetQuestions:
                     "allow_character_annotation": True,
                     "allow_overlapping": False,
                 },
+            ),
+            (
+                    {
+                        "type": "span",
+                        "field": "field-a",
+                        "visible_options": 3,
+                        "options": [
+                            {"value": "label-a", "text": "Label A"},
+                            {"value": "label-b", "text": "Label B"},
+                            {"value": "label-c", "text": "Label C"},
+                            {"value": "label-d", "text": "Label D"},
+                        ],
+                    },
+                    {
+                        "type": "span",
+                        "field": "field-a",
+                        "visible_options": 3,
+                        "options": [
+                            {"value": "label-a", "text": "Label A", "description": None},
+                            {"value": "label-b", "text": "Label B", "description": None},
+                            {"value": "label-c", "text": "Label C", "description": None},
+                            {"value": "label-d", "text": "Label D", "description": None},
+                        ],
+                        "allow_character_annotation": True,
+                        "allow_overlapping": False,
+                    },
             ),
         ],
     )

--- a/tests/unit/api/v1/test_questions.py
+++ b/tests/unit/api/v1/test_questions.py
@@ -201,6 +201,28 @@ if TYPE_CHECKING:
                 ],
                 "allow_overlapping": False,
                 "allow_character_annotation": True,
+                "visible_options": None,
+            },
+        ),
+        (
+            SpanQuestionFactory,
+            {
+                "settings": {
+                    "type": "span",
+                    "visible_options": 3,
+                }
+            },
+            {
+                "type": "span",
+                "field": "field-a",
+                "options": [
+                    {"value": "label-a", "text": "Label A", "description": "Label A description"},
+                    {"value": "label-b", "text": "Label B", "description": "Label B description"},
+                    {"value": "label-c", "text": "Label C", "description": "Label C description"},
+                ],
+                "allow_overlapping": False,
+                "allow_character_annotation": True,
+                "visible_options": 3,
             },
         ),
     ],


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds support for `visible_options` parameter for span question settings 



**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
