### PR TITLE
refactor: delete old list workspaces endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ These are the section headers that we use:
 - Add support for upserting suggestions for questions of type `span`. ([#54](https://github.com/argilla-io/argilla-server/pull/54))
 - Add `inserted_at` and `updated_at` missing fields to API v1 `Suggestion` schema. ([#52](https://github.com/argilla-io/argilla-server/pull/52))
 
+### Removed
+
+- Removed unused `GET /api/workspaces` endpoint. ([#83](https://github.com/argilla-io/argilla-server/pull/83))
+
 ### Fixed
 
 - Fixed error when returning responses from deleted users (which contains user_id=None). ([#57](https://github.com/argilla-io/argilla-server/pull/57))

--- a/src/argilla_server/apis/v0/handlers/users.py
+++ b/src/argilla_server/apis/v0/handlers/users.py
@@ -61,7 +61,7 @@ async def whoami(
     #  Returning all workspaces from the `/api/me` for owner users keeps the
     #  backward compatibility with the client flow.
     #  This logic will be removed in future versions, when python client
-    #  start using the list workspaces (`/api/workspaces`) endpoint to handle
+    #  start using the list workspaces (`/api/v1/me/workspaces`) endpoint to handle
     #  accessible workspaces for connected user.
     if current_user.is_owner:
         workspaces = await accounts.list_workspaces(db)

--- a/src/argilla_server/apis/v0/handlers/workspaces.py
+++ b/src/argilla_server/apis/v0/handlers/workspaces.py
@@ -30,17 +30,6 @@ from argilla_server.security import auth
 router = APIRouter(tags=["workspaces"])
 
 
-@router.get("/workspaces", response_model=List[Workspace], response_model_exclude_none=True)
-async def list_workspaces(
-    *, db: AsyncSession = Depends(get_async_db), current_user: User = Security(auth.get_current_user)
-):
-    await authorize(current_user, WorkspacePolicy.list)
-
-    workspaces = await accounts.list_workspaces(db)
-
-    return parse_obj_as(List[Workspace], workspaces)
-
-
 @router.post("/workspaces", response_model=Workspace, response_model_exclude_none=True)
 async def create_workspace(
     *,

--- a/tests/unit/api/v0/test_workspaces.py
+++ b/tests/unit/api/v0/test_workspaces.py
@@ -16,10 +16,10 @@ from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import func, select
-
 from argilla_server.constants import API_KEY_HEADER_NAME
 from argilla_server.models import User, Workspace, WorkspaceUser
+from sqlalchemy import func, select
+
 from tests.factories import (
     AdminFactory,
     AnnotatorFactory,

--- a/tests/unit/api/v0/test_workspaces.py
+++ b/tests/unit/api/v0/test_workspaces.py
@@ -16,11 +16,10 @@ from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 import pytest
-from argilla_server.constants import API_KEY_HEADER_NAME
-from argilla_server.models import User, Workspace, WorkspaceUser
-from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 
+from argilla_server.constants import API_KEY_HEADER_NAME
+from argilla_server.models import User, Workspace, WorkspaceUser
 from tests.factories import (
     AdminFactory,
     AnnotatorFactory,
@@ -31,44 +30,6 @@ from tests.factories import (
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
-
-
-@pytest.mark.asyncio
-async def test_list_workspaces(async_client: "AsyncClient", owner_auth_header):
-    await WorkspaceFactory.create(name="workspace-a")
-    await WorkspaceFactory.create(name="workspace-b")
-
-    response = await async_client.get("/api/workspaces", headers=owner_auth_header)
-
-    assert response.status_code == 200
-
-    response_body = response.json()
-    assert list(map(lambda ws: ws["name"], response_body)) == ["workspace-a", "workspace-b"]
-
-
-@pytest.mark.asyncio
-async def test_list_workspaces_without_authentication(async_client: "AsyncClient"):
-    response = await async_client.get("/api/workspaces")
-
-    assert response.status_code == 401
-
-
-@pytest.mark.asyncio
-async def test_list_workspaces_as_admin(async_client: "AsyncClient"):
-    admin = await AdminFactory.create()
-
-    response = await async_client.get("/api/workspaces", headers={API_KEY_HEADER_NAME: admin.api_key})
-
-    assert response.status_code == 200
-
-
-@pytest.mark.asyncio
-async def test_list_workspaces_as_annotator(async_client: "AsyncClient"):
-    annotator = await AnnotatorFactory.create()
-
-    response = await async_client.get("/api/workspaces", headers={API_KEY_HEADER_NAME: annotator.api_key})
-
-    assert response.status_code == 200
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR removes the `GET /api/workspaces` endpoint which is not used anymore for a while.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
