### PR TITLE
fix: Validate duplicated `external_id`'s and existing records with `external_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+-  Fixed errors when adding records with existing record external ids. ([#97](https://github.com/argilla-io/argilla-server/pull/97))
+
 ## [1.26.0](https://github.com/argilla-io/argilla-server/compare/v1.25.0...v1.26.0)
 
 ### Added

--- a/src/argilla_server/contexts/bulk/records/records_create_bulk.py
+++ b/src/argilla_server/contexts/bulk/records/records_create_bulk.py
@@ -33,8 +33,20 @@ class RecordsCreateBulk:
     async def create_dataset_records(self, dataset: Dataset, records_create: RecordsCreate) -> List[Record]:
         helpers.check_dataset_is_ready(dataset)
 
+        # TODO: RecordsCreateValidator(records_create).validate_for(dataset) ????
+        external_ids = [r.external_id for r in records_create.items if r.external_id is not None]
+        if len(external_ids) != len(set(external_ids)):
+            raise ValueError("Found duplicate external IDs")
+
         records = []
         async with self._db.begin_nested():
+            records_by_external_id = await helpers.fetch_records_by_external_ids(self._db, dataset, external_ids)
+            found_records = [
+                str(external_id) for external_id in external_ids if external_id in records_by_external_id
+            ]
+            if found_records:
+                raise ValueError(f"Found records with same external ids: {', '.join(found_records)}")
+
             for idx, record_create in enumerate(records_create.items):
                 try:
                     RecordCreateValidator(record_create).validate_for(dataset)


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds missing validation when creating records to check that provided records do not contain duplicated `external_id` values and do not already exist in DB.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
