### PR TITLE
chore: increase heap limit for ElasticSearch from 512m to 1g for Quickstart docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ These are the section headers that we use:
 - Added `ARGILLA_SPAN_OPTIONS_MAX_ITEMS` environment variable to set the number of maximum items to be used by span questions. By default this value is set to `500`. ([#85](https://github.com/argilla-io/argilla-server/pull/85))
 - Added `GET /api/v1/datasets/:dataset_id/progress` endpoint to return progress metrics related with one specific dataset. ([#90](https://github.com/argilla-io/argilla-server/pull/90))
 
+### Changed
+
+- Changed ElasticSearch JVM heap size from `512m` to `1g` for quickstart Dockerfile. ([#109](https://github.com/argilla-io/argilla-server/pull/109))
+
 ## [1.26.1](https://github.com/argilla-io/argilla-server/compare/v1.26.0...v1.26.1)
 
 > [!NOTE]

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -46,7 +46,7 @@ COPY config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
 
 USER argilla
 
-# NOTE: We didn't found documentation about ELASTIC_CONTAINER environment variable but it could be
+# NOTE: We have not found documentation about ELASTIC_CONTAINER environment variable but it could be
 # used to indicate that Elasticsearch is running in a container.
 # It is used in official Elastic Dockerfiles so we are not removing it for now:
 # https://github.com/search?q=repo%3Aelastic%2Fdockerfiles%20ELASTIC_CONTAINER&type=code

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -46,6 +46,10 @@ COPY config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
 
 USER argilla
 
+# NOTE: We didn't found documentation about ELASTIC_CONTAINER environment variable but it could be
+# used to indicate that Elasticsearch is running in a container.
+# It is used in official Elastic Dockerfiles so we are not removing it for now:
+# https://github.com/search?q=repo%3Aelastic%2Fdockerfiles%20ELASTIC_CONTAINER&type=code
 ENV ELASTIC_CONTAINER=true
 ENV ES_JAVA_OPTS="-Xms1g -Xmx1g"
 

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -47,6 +47,7 @@ COPY config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
 USER argilla
 
 ENV ELASTIC_CONTAINER=true
+ENV ES_JAVA_OPTS="-Xms1g -Xmx1g"
 
 ENV OWNER_USERNAME=owner
 ENV OWNER_PASSWORD=12345678
@@ -65,8 +66,5 @@ ENV ARGILLA_WORKSPACE=$ADMIN_USERNAME
 ENV UVICORN_PORT=6900
 
 ENV REINDEX_DATASETS=0
-
-# TODO: Increase by default to 1GB
-ENV ES_JAVA_OPTS=-'Xms512m -Xmx512m'
 
 CMD ["/bin/bash", "start_quickstart_argilla.sh"]


### PR DESCRIPTION
# Description

This PR fix a typo on the definition of the `ES_JAVA_OPTS` environment value and increase the heap start and maximum values from `512m` to `1g`.

The motivation for this change is coming from some users that have ElasticSearch not working properly (stop executing) on HF spaces.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Check that everything is working on HF spaces using this PR.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)