### PR TITLE
feat: move suggestion score validations to `SuggestionCreateValidator` and add a missing cardinality validation for value and score attributes

### DIFF
--- a/src/argilla_server/schemas/v1/suggestions.py
+++ b/src/argilla_server/schemas/v1/suggestions.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from argilla_server.models import SuggestionType
-from argilla_server.pydantic_v1 import BaseModel, Field, root_validator
+from argilla_server.pydantic_v1 import BaseModel, Field
 from argilla_server.schemas.v1.questions import QuestionName
 from argilla_server.schemas.v1.responses import (
     SPAN_QUESTION_RESPONSE_VALUE_MAX_ITEMS,
@@ -114,15 +114,3 @@ class SuggestionCreate(BaseSuggestion):
         description="Agent used to generate the suggestion",
     )
     score: SuggestionScoreField
-
-    @root_validator(skip_on_failure=True)
-    def check_value_and_score_length(cls, values: dict) -> dict:
-        value, score = values.get("value"), values.get("score")
-
-        if not isinstance(value, list) or not isinstance(score, list):
-            return values
-
-        if len(value) != len(score):
-            raise ValueError("number of items on value and score attributes doesn't match")
-
-        return values

--- a/src/argilla_server/validators/suggestions.py
+++ b/src/argilla_server/validators/suggestions.py
@@ -37,6 +37,13 @@ class SuggestionCreateValidator:
         if not isinstance(self._suggestion_create.value, list) and isinstance(self._suggestion_create.score, list):
             raise ValueError("a list of score values is not allowed for a suggestion with a single value")
 
+        if (
+            isinstance(self._suggestion_create.value, list)
+            and self._suggestion_create.score is not None
+            and not isinstance(self._suggestion_create.score, list)
+        ):
+            raise ValueError("a single score value is not allowed for a suggestion with a multiple items value")
+
     def _validate_value_and_score_have_same_length(self) -> None:
         if not isinstance(self._suggestion_create.value, list) or not isinstance(self._suggestion_create.score, list):
             return

--- a/src/argilla_server/validators/suggestions.py
+++ b/src/argilla_server/validators/suggestions.py
@@ -35,7 +35,7 @@ class SuggestionCreateValidator:
 
     def _validate_value_and_score_cardinality(self):
         if not isinstance(self._suggestion_create.value, list) and isinstance(self._suggestion_create.score, list):
-            raise ValueError("multiple score values are not allowed for a suggestion with a single value")
+            raise ValueError("a list of score values is not allowed for a suggestion with a single value")
 
     def _validate_value_and_score_have_same_length(self) -> None:
         if not isinstance(self._suggestion_create.value, list) or not isinstance(self._suggestion_create.score, list):

--- a/src/argilla_server/validators/suggestions.py
+++ b/src/argilla_server/validators/suggestions.py
@@ -24,6 +24,22 @@ class SuggestionCreateValidator:
 
     def validate_for(self, question_settings: QuestionSettings, record: Record) -> None:
         self._validate_value(question_settings, record)
+        self._validate_score()
 
     def _validate_value(self, question_settings: QuestionSettings, record: Record) -> None:
         ResponseValueValidator(self._suggestion_create.value).validate_for(question_settings, record)
+
+    def _validate_score(self):
+        self._validate_value_and_score_cardinality()
+        self._validate_value_and_score_have_same_length()
+
+    def _validate_value_and_score_cardinality(self):
+        if not isinstance(self._suggestion_create.value, list) and isinstance(self._suggestion_create.score, list):
+            raise ValueError("multiple score values are not allowed for a suggestion with a single value")
+
+    def _validate_value_and_score_have_same_length(self) -> None:
+        if not isinstance(self._suggestion_create.value, list) or not isinstance(self._suggestion_create.score, list):
+            return
+
+        if len(self._suggestion_create.value) != len(self._suggestion_create.score):
+            raise ValueError("number of items on value and score attributes doesn't match")

--- a/tests/unit/api/v1/datasets/records/test_create_dataset_records.py
+++ b/tests/unit/api/v1/datasets/records/test_create_dataset_records.py
@@ -172,7 +172,7 @@ class TestCreateDatasetRecords:
                             },
                             {
                                 "type": SuggestionType.model,
-                                "score": 1.0,
+                                "score": [1.0, 0.1],
                                 "value": [
                                     "label-a",
                                     "label-b",
@@ -187,7 +187,7 @@ class TestCreateDatasetRecords:
                             },
                             {
                                 "type": SuggestionType.model,
-                                "score": 0.5,
+                                "score": [0.2, 0.5],
                                 "value": [
                                     {"value": "ranking-a", "rank": 1},
                                     {"value": "ranking-b", "rank": 2},

--- a/tests/unit/api/v1/datasets/records/test_update_dataset_records.py
+++ b/tests/unit/api/v1/datasets/records/test_update_dataset_records.py
@@ -143,7 +143,7 @@ class TestUpdateDatasetRecords:
                             },
                             {
                                 "type": SuggestionType.model,
-                                "score": 1.0,
+                                "score": [1.0, 0.1],
                                 "value": [
                                     "label-a",
                                     "label-b",
@@ -158,7 +158,7 @@ class TestUpdateDatasetRecords:
                             },
                             {
                                 "type": SuggestionType.model,
-                                "score": 0.5,
+                                "score": [0.2, 0.5],
                                 "value": [
                                     {"value": "ranking-a", "rank": 1},
                                     {"value": "ranking-b", "rank": 2},

--- a/tests/unit/api/v1/records/test_upsert_suggestion.py
+++ b/tests/unit/api/v1/records/test_upsert_suggestion.py
@@ -284,7 +284,7 @@ class TestUpsertSuggestion:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": "multiple score values are not allowed for a suggestion with a single value"
+            "detail": "a list of score values is not allowed for a suggestion with a single value"
         }
 
     @pytest.mark.parametrize("score", [[1.0], [1.0, 0.5], [1.0, 0.5, 0.9, 0.3]])


### PR DESCRIPTION
# Description

This PR move all suggestion `score` validations to `SuggestionCreateValidator` and add a new one checking that `value` and `score` attributes have the same cardinality.

The additional validation will raise an error when a suggestion have a single item inside `value` attribute and a list of items inside `score`.

Refs https://github.com/argilla-io/argilla/issues/4638

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Adding new tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)