### PR TITLE
feat: expose Hugging Face spaces environment variables on `/api/_status` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Added
+
+- Added `huggingface` attribute to `GET /api/_status` endpoint exposing Hugging Face Spaces environment variables. ([#121](https://github.com/argilla-io/argilla-server/pull/121))
+
 ## [1.27.0](https://github.com/argilla-io/argilla-server/compare/v1.26.1...v1.27.0)
 
 ### Added

--- a/src/argilla_server/apis/v0/handlers/info.py
+++ b/src/argilla_server/apis/v0/handlers/info.py
@@ -20,7 +20,7 @@ from argilla_server.services.info import ApiInfo, ApiInfoService, ApiStatus
 router = APIRouter(tags=["status"])
 
 
-@router.get("/_status", operation_id="api_status", response_model=ApiStatus)
+@router.get("/_status", operation_id="api_status", response_model=ApiStatus, response_model_exclude_none=True)
 async def api_status(service: ApiInfoService = Depends(ApiInfoService.get_instance)) -> ApiStatus:
     return service.api_status()
 

--- a/tests/unit/api/v0/info/__init__.py
+++ b/tests/unit/api/v0/info/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/api/v0/info/test_api_status.py
+++ b/tests/unit/api/v0/info/test_api_status.py
@@ -1,0 +1,59 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+from unittest import mock
+
+import pytest
+from argilla_server.services import info
+from argilla_server.services.info import HuggingfaceInfo
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestApiStatus:
+    def url(self) -> str:
+        return "/api/_status"
+
+    async def test_api_status_with_huggingface_info(self, async_client: AsyncClient):
+        huggingface_os_environ = {
+            "SPACE_ID": "space-id",
+            "SPACE_TITLE": "space-title",
+            "SPACE_SUBDOMAIN": "space-subdomain",
+            "SPACE_HOST": "space-host",
+            "SPACE_REPO_NAME": "space-repo-name",
+            "SPACE_AUTHOR_NAME": "space-author-name",
+            "PERSISTANT_STORAGE_ENABLED": "true",
+        }
+
+        with mock.patch.dict(os.environ, huggingface_os_environ):
+            with mock.patch.object(info, "_huggingface_info", HuggingfaceInfo()):
+                response = await async_client.get(self.url())
+
+                assert response.status_code == 200
+                assert response.json()["huggingface"] == {
+                    "space_id": "space-id",
+                    "space_title": "space-title",
+                    "space_subdomain": "space-subdomain",
+                    "space_host": "space-host",
+                    "space_repo_name": "space-repo-name",
+                    "space_author_name": "space-author-name",
+                    "space_persistant_storage_enabled": True,
+                }
+
+    async def test_api_status_with_no_huggingface_info(self, async_client: AsyncClient):
+        response = await async_client.get(self.url())
+
+        assert response.status_code == 200
+        assert "huggingface" not in response.json()


### PR DESCRIPTION
# Description

This PR add changes to `/api/_status` endpoint exposing Hugging Face spaces environment variables only when a `SPACE_ID` environment variable is available.

The response of the endpoint will gain a new `huggingface` attribute with the following structure:

```json
{
    "space_id": "space-id",
    "space_title": "space-title",
    "space_subdomain": "space-subdomain",
    "space_host": "space-host",
    "space_repo_name": "space-repo-name",
    "space_author_name": "space-author-name",
    "space_persistant_storage_enabled": true
}
```

If `SPACE_ID` environment variable is not available so we are not running Argilla inside a Hugging Face space then the `huggingface` attribute inside the response will not be available.

> [!NOTE]
> I will add an additional PR including a new setting so it's possible to disable the warning when persistant storage is disabled.

Closes #120 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Add new tests to our suite.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)