### PR TITLE
feat: add new endpoint to create user tokens on API v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+- Added `POST /api/v1/token` endpoint to generate a new API token for a user. ([#138](https://github.com/argilla-io/argilla-server/pull/138))
+
+## [Unreleased]()
+
 ### Added
 
 - Added support to specify a list of score values for suggestions `score` attribute. ([#98](https://github.com/argilla-io/argilla-server/pull/98))

--- a/src/argilla_server/apis/routes.py
+++ b/src/argilla_server/apis/routes.py
@@ -35,6 +35,7 @@ from argilla_server.apis.v0.handlers import (
     users,
     workspaces,
 )
+from argilla_server.apis.v1.handlers import authentication as authentication_v1
 from argilla_server.apis.v1.handlers import (
     datasets as datasets_v1,
 )
@@ -113,6 +114,7 @@ def create_api_v1():
     APIErrorHandler.configure_app(api_v1)
 
     for router in [
+        authentication_v1.router,
         datasets_v1.router,
         fields_v1.router,
         questions_v1.router,

--- a/src/argilla_server/apis/v1/handlers/authentication.py
+++ b/src/argilla_server/apis/v1/handlers/authentication.py
@@ -1,0 +1,39 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Form
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from argilla_server.contexts import accounts
+from argilla_server.database import get_async_db
+from argilla_server.errors import UnauthorizedError
+from argilla_server.schemas.v1.oauth2 import Token
+
+router = APIRouter(tags=["Authentication"])
+
+
+@router.post("/token", response_model=Token)
+async def create_token(
+    *,
+    db: AsyncSession = Depends(get_async_db),
+    username: Annotated[str, Form()],
+    password: Annotated[str, Form()],
+):
+    user = await accounts.authenticate_user(db, username, password)
+    if not user:
+        raise UnauthorizedError()
+
+    return Token(access_token=accounts.generate_user_token(user))

--- a/src/argilla_server/contexts/accounts.py
+++ b/src/argilla_server/contexts/accounts.py
@@ -24,6 +24,8 @@ from argilla_server.enums import UserRole
 from argilla_server.models import User, Workspace, WorkspaceUser
 from argilla_server.schemas.v0.users import UserCreate
 from argilla_server.schemas.v0.workspaces import WorkspaceCreate, WorkspaceUserCreate
+from argilla_server.security.authentication.jwt import JWT
+from argilla_server.security.authentication.userinfo import UserInfo
 
 _CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -186,6 +188,17 @@ def verify_password(password: str, password_hash: str) -> bool:
 
 def _generate_random_password() -> str:
     return secrets.token_urlsafe()
+
+
+def generate_user_token(user: User) -> str:
+    return JWT.create(
+        UserInfo(
+            identity=str(user.id),
+            name=user.first_name,
+            username=user.username,
+            role=user.role,
+        ),
+    )
 
 
 async def fetch_users_by_ids_as_dict(db: "AsyncSession", user_ids: List[UUID]) -> Dict[UUID, User]:

--- a/tests/unit/api/v1/authentication/__init__.py
+++ b/tests/unit/api/v1/authentication/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/api/v1/authentication/test_create_token.py
+++ b/tests/unit/api/v1/authentication/test_create_token.py
@@ -20,20 +20,47 @@ from tests.factories import UserFactory
 
 
 @pytest.mark.asyncio
-class TestsAuthentication:
-    async def test_authenticate(self, async_client: AsyncClient):
+class TestsCreateToken:
+    def url(self) -> str:
+        return "/api/v1/token"
+
+    async def test_create_token(self, async_client: AsyncClient):
         user = await UserFactory.create()
 
         response = await async_client.post(
-            "/api/security/token",
-            data={"username": user.username, "password": "1234"},
+            self.url(),
+            data={
+                "username": user.username,
+                "password": "1234",
+            },
         )
+
         assert response.status_code == 200
         assert response.json()["access_token"]
         assert response.json()["token_type"] == "bearer"
 
-    async def test_invalid_credentials(self, async_client: AsyncClient, owner: User):
+    async def test_create_token_with_invalid_username(self, async_client: AsyncClient):
+        user = await UserFactory.create()
+
         response = await async_client.post(
-            "/api/security/token", data={"username": owner.username, "password": "invalid"}
+            self.url(),
+            data={
+                "username": "invalid-username",
+                "password": "1234",
+            },
         )
+
+        assert response.status_code == 401
+
+    async def test_create_token_with_invalid_password(self, async_client: AsyncClient):
+        user = await UserFactory.create()
+
+        response = await async_client.post(
+            self.url(),
+            data={
+                "username": user.username,
+                "password": "invalid-password",
+            },
+        )
+
         assert response.status_code == 401


### PR DESCRIPTION
# Description

This PR implements a new endpoint on API v1 to create tokens for users. It works the same than the one in API v0 with small changes.

The new endpoint created is `POST /api/v1/token`. I have used `/token` instead of `/login` because I think we are creating tokens and it's better if we continue using that naming for it. 

@frascuchon tell me if we still have a good reason for rename it to `/login` and I will change it if necessary.

Closes #137 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [x] Adding new tests.
- [x] I have check that old tests are passing using the new endpoint too. 

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)