### PR TITLE
feat: migrate `/api/me` endpoint to `/api/v1/me`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ These are the section headers that we use:
 ## [Unreleased]()
 
 - Added `POST /api/v1/token` endpoint to generate a new API token for a user. ([#138](https://github.com/argilla-io/argilla-server/pull/138))
+- Added `GET /api/v1/me` endpoint to get the current user information. ([#140](https://github.com/argilla-io/argilla-server/pull/140))
 
 ## [Unreleased]()
 

--- a/src/argilla_server/apis/v1/handlers/users.py
+++ b/src/argilla_server/apis/v1/handlers/users.py
@@ -21,10 +21,18 @@ from argilla_server.contexts import accounts
 from argilla_server.database import get_async_db
 from argilla_server.models import User
 from argilla_server.policies import UserPolicyV1, authorize
+from argilla_server.schemas.v1.users import User as UserSchema
 from argilla_server.schemas.v1.workspaces import Workspaces
 from argilla_server.security import auth
 
 router = APIRouter(tags=["users"])
+
+
+@router.get("/me", response_model=UserSchema)
+async def get_current_user(current_user: User = Security(auth.get_current_user)):
+    # TODO: Should we add telemetry.track_login?
+
+    return current_user
 
 
 @router.get("/users/{user_id}/workspaces", response_model=Workspaces)

--- a/src/argilla_server/schemas/v1/users.py
+++ b/src/argilla_server/schemas/v1/users.py
@@ -1,0 +1,34 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from argilla_server.enums import UserRole
+from argilla_server.pydantic_v1 import BaseModel
+
+
+class User(BaseModel):
+    id: UUID
+    first_name: str
+    last_name: Optional[str]
+    username: str
+    role: UserRole
+    api_key: str
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/tests/unit/api/v1/users/__init__.py
+++ b/tests/unit/api/v1/users/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/api/v1/users/test_get_current_user.py
+++ b/tests/unit/api/v1/users/test_get_current_user.py
@@ -1,0 +1,43 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla_server.models import User
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestGetCurrentUser:
+    def url(self) -> str:
+        return "/api/v1/me"
+
+    async def test_get_current_user(self, async_client: AsyncClient, owner: User, owner_auth_header: dict):
+        response = await async_client.get(self.url(), headers=owner_auth_header)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": str(owner.id),
+            "first_name": owner.first_name,
+            "last_name": owner.last_name,
+            "username": owner.username,
+            "role": owner.role,
+            "api_key": owner.api_key,
+            "inserted_at": owner.inserted_at.isoformat(),
+            "updated_at": owner.updated_at.isoformat(),
+        }
+
+    async def test_get_current_user_without_authentication(self, async_client: AsyncClient):
+        response = await async_client.get(self.url())
+
+        assert response.status_code == 401


### PR DESCRIPTION
# Description

This PR creates a new `/api/v1/me` endpoint with similar functionality to the old `/me` endpoint from API v0.

The following changes are included:
* `full_name` user attribute is not used in the new `User` v1 schema. Instead the frontend should concatenate `first_name` and `last_name` if necessary.
* `workspaces` user attribute is not used in the new `User` v1 schema. `/api/v1/me/workspaces` could be used instead.

Closes #139

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Adding new tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)