### PR TITLE
feat: migrate `POST /api/workspaces` endpoint to `POST /api/v1/workspaces`

### DIFF
--- a/src/argilla_server/apis/v0/handlers/workspaces.py
+++ b/src/argilla_server/apis/v0/handlers/workspaces.py
@@ -42,7 +42,7 @@ async def create_workspace(
     if await accounts.get_workspace_by_name(db, workspace_create.name):
         raise EntityAlreadyExistsError(name=workspace_create.name, type=Workspace)
 
-    workspace = await accounts.create_workspace(db, workspace_create)
+    workspace = await accounts.create_workspace(db, workspace_create.dict())
 
     return Workspace.from_orm(workspace)
 

--- a/src/argilla_server/apis/v1/handlers/authentication.py
+++ b/src/argilla_server/apis/v1/handlers/authentication.py
@@ -14,7 +14,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Form
+from fastapi import APIRouter, Depends, Form, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla_server.contexts import accounts
@@ -25,7 +25,7 @@ from argilla_server.schemas.v1.oauth2 import Token
 router = APIRouter(tags=["Authentication"])
 
 
-@router.post("/token", response_model=Token)
+@router.post("/token", status_code=status.HTTP_201_CREATED, response_model=Token)
 async def create_token(
     *,
     db: AsyncSession = Depends(get_async_db),

--- a/src/argilla_server/apis/v1/handlers/workspaces.py
+++ b/src/argilla_server/apis/v1/handlers/workspaces.py
@@ -19,9 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla_server.contexts import accounts, datasets
 from argilla_server.database import get_async_db
+from argilla_server.errors import EntityAlreadyExistsError
 from argilla_server.models import User
 from argilla_server.policies import WorkspacePolicyV1, authorize
-from argilla_server.schemas.v1.workspaces import Workspace, Workspaces
+from argilla_server.schemas.v1.workspaces import Workspace, WorkspaceCreate, Workspaces
 from argilla_server.security import auth
 from argilla_server.services.datasets import DatasetsService
 
@@ -45,6 +46,21 @@ async def get_workspace(
         )
 
     return workspace
+
+
+@router.post("/workspaces", status_code=status.HTTP_201_CREATED, response_model=Workspace)
+async def create_workspace(
+    *,
+    db: AsyncSession = Depends(get_async_db),
+    workspace_create: WorkspaceCreate,
+    current_user: User = Security(auth.get_current_user),
+):
+    await authorize(current_user, WorkspacePolicyV1.create)
+
+    if await accounts.get_workspace_by_name(db, workspace_create.name):
+        raise EntityAlreadyExistsError(name=workspace_create.name, type=Workspace)
+
+    return await accounts.create_workspace(db, workspace_create.dict())
 
 
 @router.delete("/workspaces/{workspace_id}", response_model=Workspace)

--- a/src/argilla_server/contexts/accounts.py
+++ b/src/argilla_server/contexts/accounts.py
@@ -75,8 +75,8 @@ async def list_workspaces_by_user_id(db: AsyncSession, user_id: UUID) -> List[Wo
     return result.scalars().all()
 
 
-async def create_workspace(db: AsyncSession, workspace_create: WorkspaceCreate) -> Workspace:
-    return await Workspace.create(db, schema=workspace_create)
+async def create_workspace(db: AsyncSession, workspace_attrs: dict) -> Workspace:
+    return await Workspace.create(db, name=workspace_attrs["name"])
 
 
 async def delete_workspace(db: AsyncSession, workspace: Workspace):

--- a/src/argilla_server/policies.py
+++ b/src/argilla_server/policies.py
@@ -103,6 +103,10 @@ class WorkspacePolicyV1:
         return is_allowed
 
     @classmethod
+    async def create(cls, actor: User) -> bool:
+        return actor.is_owner
+
+    @classmethod
     async def delete(cls, actor: User) -> bool:
         return actor.is_owner
 

--- a/tests/unit/api/v1/authentication/test_create_token.py
+++ b/tests/unit/api/v1/authentication/test_create_token.py
@@ -35,7 +35,7 @@ class TestsCreateToken:
             },
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.json()["access_token"]
         assert response.json()["token_type"] == "bearer"
 

--- a/tests/unit/api/v1/workspaces/__init__.py
+++ b/tests/unit/api/v1/workspaces/__init__.py
@@ -11,30 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from datetime import datetime
-from typing import List
-from uuid import UUID
-
-from argilla_server.constants import ES_INDEX_REGEX_PATTERN
-from argilla_server.pydantic_v1 import BaseModel, Field
-
-WORKSPACE_NAME_REGEX = ES_INDEX_REGEX_PATTERN
-
-
-class Workspace(BaseModel):
-    id: UUID
-    name: str
-    inserted_at: datetime
-    updated_at: datetime
-
-    class Config:
-        orm_mode = True
-
-
-class WorkspaceCreate(BaseModel):
-    name: str = Field(regex=WORKSPACE_NAME_REGEX, min_length=1)
-
-
-class Workspaces(BaseModel):
-    items: List[Workspace]

--- a/tests/unit/api/v1/workspaces/test_create_workspace.py
+++ b/tests/unit/api/v1/workspaces/test_create_workspace.py
@@ -1,0 +1,110 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla_server.constants import API_KEY_HEADER_NAME
+from argilla_server.enums import UserRole
+from argilla_server.models import Workspace
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.factories import UserFactory, WorkspaceFactory
+
+
+@pytest.mark.asyncio
+class TestCreateWorkspace:
+    def url(self) -> str:
+        return "/api/v1/workspaces"
+
+    async def test_create_workspace(self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict):
+        response = await async_client.post(
+            self.url(),
+            headers=owner_auth_header,
+            json={"name": "workspace"},
+        )
+
+        assert response.status_code == 201
+
+        assert (await db.execute(select(func.count(Workspace.id)))).scalar() == 1
+        workspace = (await db.execute(select(Workspace).filter_by(name="workspace"))).scalar_one()
+
+        assert response.json() == {
+            "id": str(workspace.id),
+            "name": "workspace",
+            "inserted_at": workspace.inserted_at.isoformat(),
+            "updated_at": workspace.updated_at.isoformat(),
+        }
+
+    async def test_create_workspace_without_authentication(self, db: AsyncSession, async_client: AsyncClient):
+        response = await async_client.post(
+            self.url(),
+            json={"name": "workspace"},
+        )
+
+        assert response.status_code == 401
+        assert (await db.execute(select(func.count(Workspace.id)))).scalar() == 0
+
+    @pytest.mark.parametrize("user_role", [UserRole.admin, UserRole.annotator])
+    async def test_create_workspace_with_unauthorized_role(
+        self, db: AsyncSession, async_client: AsyncClient, user_role: UserRole
+    ):
+        user = await UserFactory.create(role=user_role)
+
+        response = await async_client.post(
+            self.url(),
+            headers={API_KEY_HEADER_NAME: user.api_key},
+            json={"name": "workspace"},
+        )
+
+        assert response.status_code == 403
+        assert (await db.execute(select(func.count(Workspace.id)))).scalar() == 0
+
+    async def test_create_workspace_with_existent_name(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        await WorkspaceFactory.create(name="workspace")
+
+        response = await async_client.post(
+            self.url(),
+            headers=owner_auth_header,
+            json={"name": "workspace"},
+        )
+
+        assert response.status_code == 409
+        assert (await db.execute(select(func.count(Workspace.id)))).scalar() == 1
+
+    async def test_create_workspace_with_invalid_name(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        response = await async_client.post(
+            self.url(),
+            headers=owner_auth_header,
+            json={"name": "invalid name"},
+        )
+
+        assert response.status_code == 422
+        assert (await db.execute(select(func.count(Workspace.id)))).scalar() == 0
+
+    async def test_create_workspace_with_invalid_min_length_name(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        response = await async_client.post(
+            self.url(),
+            headers=owner_auth_header,
+            json={"name": ""},
+        )
+
+        assert response.status_code == 422
+        assert (await db.execute(select(func.count(Workspace.id)))).scalar() == 0


### PR DESCRIPTION
# Description

This PR adds a new endpoint `POST /api/v1/workspace` allowing the creation of new workspaces for API v1.

Changes of the new endpoint compared to the old one:
* The new endpoint returns a `201` status code instead of the `200` returned by the old endpoint.

Closes #149

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [x] Adding new tests and manually checking the old ones pass with the new endpoint. 

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)