### PR TITLE
fix: HF typo using persistent instead of persistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ These are the section headers that we use:
 
 - Added support to specify a list of score values for suggestions `score` attribute. ([#98](https://github.com/argilla-io/argilla-server/pull/98))
 - Added `GET /api/v1/settings` new endpoint exposing Argilla and Hugging Face settings when available. ([#127](https://github.com/argilla-io/argilla-server/pull/127))
-- Added `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` new environment variable to disable warning message when Hugging Face Spaces persistent storage is disabled. ([#124](https://github.com/argilla-io/argilla-server/pull/124))
+- Added `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTENT_STORAGE_WARNING` new environment variable to disable warning message when Hugging Face Spaces persistent storage is disabled. ([#124](https://github.com/argilla-io/argilla-server/pull/124))
 - Added `options_order` new settings attribute to support specify an order for options in multi label selection questions. ([#133](https://github.com/argilla-io/argilla-server/pull/133))
 - Added `POST /api/v1/datasets/:dataset_id/records/bulk` endpoint. ([#106](https://github.com/argilla-io/argilla-server/pull/106))
 - Added `PUT /api/v1/datasets/:dataset_id/records/bulk` endpoint. ([#106](https://github.com/argilla-io/argilla-server/pull/106))

--- a/src/argilla_server/contexts/settings.py
+++ b/src/argilla_server/contexts/settings.py
@@ -31,8 +31,8 @@ def _get_argilla_settings() -> ArgillaSettings:
     argilla_settings = ArgillaSettings()
 
     if _get_huggingface_settings():
-        argilla_settings.show_huggingface_space_persistant_storage_warning = (
-            settings.show_huggingface_space_persistant_storage_warning
+        argilla_settings.show_huggingface_space_persistent_storage_warning = (
+            settings.show_huggingface_space_persistent_storage_warning
         )
 
     return argilla_settings

--- a/src/argilla_server/schemas/v1/settings.py
+++ b/src/argilla_server/schemas/v1/settings.py
@@ -18,7 +18,7 @@ from argilla_server.pydantic_v1 import BaseModel, BaseSettings, Field
 
 
 class ArgillaSettings(BaseModel):
-    show_huggingface_space_persistant_storage_warning: Optional[bool]
+    show_huggingface_space_persistent_storage_warning: Optional[bool]
 
 
 class HuggingfaceSettings(BaseSettings):
@@ -28,7 +28,9 @@ class HuggingfaceSettings(BaseSettings):
     space_host: str = Field(None, env="SPACE_HOST")
     space_repo_name: str = Field(None, env="SPACE_REPO_NAME")
     space_author_name: str = Field(None, env="SPACE_AUTHOR_NAME")
-    space_persistant_storage_enabled: bool = Field(False, env="PERSISTANT_STORAGE_ENABLED")
+    # NOTE: Hugging Face has a typo in their environment variable name,
+    # using PERSISTANT instead of PERSISTENT. We will use the correct spelling in our code.
+    space_persistent_storage_enabled: bool = Field(False, env="PERSISTANT_STORAGE_ENABLED")
 
     @property
     def is_running_on_huggingface(self) -> bool:

--- a/src/argilla_server/settings.py
+++ b/src/argilla_server/settings.py
@@ -128,9 +128,9 @@ class Settings(BaseSettings):
     )
 
     # Hugging Face settings
-    show_huggingface_space_persistant_storage_warning: bool = Field(
+    show_huggingface_space_persistent_storage_warning: bool = Field(
         default=True,
-        description="If True, show a warning when Hugging Face space persistant storage is disabled",
+        description="If True, show a warning when Hugging Face space persistent storage is disabled",
     )
 
     # See also the telemetry.py module

--- a/tests/unit/api/v1/settings/test_get_settings.py
+++ b/tests/unit/api/v1/settings/test_get_settings.py
@@ -34,26 +34,26 @@ class TestGetSettings:
 
             assert response.status_code == 200
             assert response.json()["argilla"] == {
-                "show_huggingface_space_persistant_storage_warning": True,
+                "show_huggingface_space_persistent_storage_warning": True,
             }
 
     async def test_get_settings_for_argilla_settings_running_on_huggingface_with_disabled_storage_warning(
         self, async_client: AsyncClient
     ):
         with mock.patch.object(HUGGINGFACE_SETTINGS, "space_id", "space-id"):
-            with mock.patch.object(argilla_server_settings, "show_huggingface_space_persistant_storage_warning", False):
+            with mock.patch.object(argilla_server_settings, "show_huggingface_space_persistent_storage_warning", False):
                 response = await async_client.get(self.url())
 
                 assert response.status_code == 200
                 assert response.json()["argilla"] == {
-                    "show_huggingface_space_persistant_storage_warning": False,
+                    "show_huggingface_space_persistent_storage_warning": False,
                 }
 
     async def test_get_settings_for_argilla_settings_not_running_on_huggingface(self, async_client: AsyncClient):
         response = await async_client.get(self.url())
 
         assert response.status_code == 200
-        assert "show_huggingface_space_persistant_storage_warning" not in response.json()["argilla"]
+        assert "show_huggingface_space_persistent_storage_warning" not in response.json()["argilla"]
 
     async def test_get_settings_for_huggingface_settings_running_on_huggingface(self, async_client: AsyncClient):
         huggingface_os_environ = {
@@ -78,7 +78,7 @@ class TestGetSettings:
                     "space_host": "space-host",
                     "space_repo_name": "space-repo-name",
                     "space_author_name": "space-author-name",
-                    "space_persistant_storage_enabled": True,
+                    "space_persistent_storage_enabled": True,
                 }
 
     async def test_get_settings_for_huggingface_settings_not_running_on_huggingface(self, async_client: AsyncClient):


### PR DESCRIPTION
# Description

We know that the exposed environment variable from HF has a typo using `PERSISTANT_STORAGE_ENABLED` instead of `PERSISTENT_STORAGE_ENABLED`.

Instead of aligning with that typo with this PR we will use the correct spelling even if internally we are using the HF environment variable with the typo.

Refs #123 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Tests should be passing.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)