### PR TITLE
feat: migrate `/api/_info` endpoint to `/api/v1/version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These are the section headers that we use:
 
 - Added `POST /api/v1/token` endpoint to generate a new API token for a user. ([#138](https://github.com/argilla-io/argilla-server/pull/138))
 - Added `GET /api/v1/me` endpoint to get the current user information. ([#140](https://github.com/argilla-io/argilla-server/pull/140))
+- Added `GET /api/v1/version` endpoin to get the current Argilla version. ([#162](https://github.com/argilla-io/argilla-server/pull/162))
 
 ## [Unreleased]()
 

--- a/src/argilla_server/apis/routes.py
+++ b/src/argilla_server/apis/routes.py
@@ -42,6 +42,7 @@ from argilla_server.apis.v1.handlers import (
 from argilla_server.apis.v1.handlers import (
     fields as fields_v1,
 )
+from argilla_server.apis.v1.handlers import info as info_v1
 from argilla_server.apis.v1.handlers import (
     metadata_properties as metadata_properties_v1,
 )
@@ -114,6 +115,7 @@ def create_api_v1():
     APIErrorHandler.configure_app(api_v1)
 
     for router in [
+        info_v1.router,
         authentication_v1.router,
         datasets_v1.router,
         fields_v1.router,

--- a/src/argilla_server/apis/v1/handlers/info.py
+++ b/src/argilla_server/apis/v1/handlers/info.py
@@ -1,0 +1,25 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from fastapi import APIRouter
+
+from argilla_server._version import __version__
+from argilla_server.schemas.v1.info import Version
+
+router = APIRouter(tags=["info"])
+
+
+@router.get("/version", response_model=Version)
+async def get_version():
+    return Version(version=__version__)

--- a/src/argilla_server/schemas/v1/info.py
+++ b/src/argilla_server/schemas/v1/info.py
@@ -1,0 +1,19 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla_server.pydantic_v1 import BaseModel
+
+
+class Version(BaseModel):
+    version: str

--- a/tests/unit/api/v1/info/__init__.py
+++ b/tests/unit/api/v1/info/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/api/v1/info/test_get_version.py
+++ b/tests/unit/api/v1/info/test_get_version.py
@@ -1,0 +1,29 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla_server._version import __version__
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestGetVersion:
+    def url(self) -> str:
+        return "/api/v1/version"
+
+    async def test_get_version(self, async_client: AsyncClient):
+        response = await async_client.get(self.url())
+
+        assert response.status_code == 200
+        assert response.json() == {"version": __version__}


### PR DESCRIPTION
# Description

With this PR I'm creating a new endpoint on API v1 `GET /api/v1/version` to return the current argilla version.

I renamed it to `/api/v1/version` instead of `/api/v1/info` because at the end we are only returning the version.

Closes #161

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [x] Added new tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)